### PR TITLE
Simple crud for evaluators

### DIFF
--- a/app/controllers/admin/evaluators_controller.rb
+++ b/app/controllers/admin/evaluators_controller.rb
@@ -1,0 +1,52 @@
+class Admin::EvaluatorsController < Admin::ApplicationController
+  before_action :find_evaluator, only: %i[ show edit update destroy ]
+
+  def index
+    @evaluators = Evaluator.all
+  end
+
+  def show
+  end
+
+  def new
+    @evaluator = Evaluator.new
+  end
+
+  def create
+    @evaluator = Evaluator.new(evaluator_params)
+
+    if @evaluator.save
+      redirect_to admin_evaluator_path(@evaluator), notice: "Evaluator was successfully created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @evaluator.update(evaluator_params)
+      redirect_to admin_evaluator_path(@evaluator), notice: "Evaluator was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @evaluator.destroy
+      redirect_to admin_evaluators_path, notice: "Evaluator \"#{@evaluator}\" was sucessfully deleted."
+    else
+      redirect_to admin_evaluator_path(@evaluator), alert: "Unable to delete evaluator."
+    end
+  end
+
+  private
+    def evaluator_params
+      params.required(:evaluator).permit(:name)
+    end
+
+    def find_evaluator
+      @evaluator = Evaluator.find(params[:id])
+    end
+end

--- a/app/models/evaluator.rb
+++ b/app/models/evaluator.rb
@@ -7,4 +7,6 @@ class Evaluator < ApplicationRecord
   has_many :evaluations, dependent: :destroy
 
   validates :name, presence: true
+
+  def to_s = name
 end

--- a/app/views/admin/evaluators/_evaluator.html.erb
+++ b/app/views/admin/evaluators/_evaluator.html.erb
@@ -1,0 +1,20 @@
+
+<%# locals: (evaluator:) %>
+
+<li class="flex flex-wrap items-center justify-between gap-x-6 gap-y-4 py-5 sm:flex-nowrap">
+  <div>
+    <p class="text-sm font-semibold leading-6 text-gray-900">
+      <%= link_to evaluator, [:admin, evaluator], class: "hover:unerline" %>
+    </p>
+    <div class="mt-1 flex items-center gap-x-2 text-xs leading-5 text-gray-500">
+      <p>created at: <time datetime="<%= evaluator.created_at %>"><%= time_ago_in_words evaluator.created_at %> ago</time></p>
+      <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current">
+        <circle cx="1" cy="1" r="1" />
+      </svg>
+      <p>updated at:<time datetime="<%= evaluator.updated_at %>"><%= time_ago_in_words evaluator.updated_at %> ago</time></p>
+    </div>
+  </div>
+  <dl class="flex w-full flex-none justify-between gap-x-8 sm:w-auto">
+    <!-- Placeholder for actions? -->
+  </dl>
+</li>

--- a/app/views/admin/evaluators/_form.html.erb
+++ b/app/views/admin/evaluators/_form.html.erb
@@ -1,0 +1,26 @@
+<%# locals: (evaluator:) %>
+
+<%= form_with(model: evaluator, url: [:admin, evaluator], class: "contents") do |form| %>
+  <% if evaluator.errors.any? %>
+    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
+      <h2><%= pluralize(evaluator.errors.count, "error") %> prohibited this evaluator from being saved:</h2>
+
+      <ul>
+        <% evaluator.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="space-y-12">
+    <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+      <%= form.text_field :name, wrapper: "sm:col-span-4" %>
+    </div>
+  </div>
+
+  <div class="mt-6 flex items-center justify-end gap-x-6">
+    <%= link_to "Cancel", [:admin, evaluator], class: "btn btn-primary" %>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/evaluators/edit.html.erb
+++ b/app/views/admin/evaluators/edit.html.erb
@@ -1,0 +1,5 @@
+<% breadcrumb :edit_admin_evaluator, @evaluator %>
+
+<%= mltop_title @evaluator.name %>
+
+<%= render "form", evaluator: @evaluator %>

--- a/app/views/admin/evaluators/index.html.erb
+++ b/app/views/admin/evaluators/index.html.erb
@@ -1,0 +1,12 @@
+<% breadcrumb :admin_evaluators %>
+
+<div class="border-b border-gray-200 pb-5 sm:flex sm:items-center sm:justify-between">
+  <h3 class="text-base font-semibold leading-6 text-gray-900">Evaluators</h3>
+  <div class="mt-3 flex sm:ml-4 sm:mt-0">
+    <%= link_to "New evaluator", new_admin_evaluator_path, class: "btn btn-success" %>
+  </div>
+</div>
+
+<ul role="list" class="divide-y divide-gray-100 px-4">
+  <%= render @evaluators %>
+</ul>

--- a/app/views/admin/evaluators/new.html.erb
+++ b/app/views/admin/evaluators/new.html.erb
@@ -1,0 +1,5 @@
+<% breadcrumb :new_admin_evaluator %>
+
+<%= mltop_title "New evaluator" %>
+
+<%= render "form", evaluator: @evaluator %>

--- a/app/views/admin/evaluators/show.html.erb
+++ b/app/views/admin/evaluators/show.html.erb
@@ -1,0 +1,16 @@
+<% breadcrumb :admin_evaluator, @evaluator %>
+
+<div>
+  <div class="px-4 sm:px-0">
+    <div class="sm:flex sm:items-start sm:justify-between">
+      <div>
+        <h3 class="text-base font-semibold leading-7 text-gray-900"><%= @evaluator %></h3>
+      </div>
+      <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center space-x-2">
+        <%= link_to "Edit", [:edit, :admin, @evaluator], type:"button", class: "btn btn-warning" %>
+        <%= button_to "Delete", [:admin, @evaluator], method: :delete, class: "btn btn-danger",
+          form: { "data-turbo-confirm": "Are you sure you want to remove this evaluator? All related evaluations and calculated scores will be removed" } %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/admin/_menu.html.erb
+++ b/app/views/layouts/admin/_menu.html.erb
@@ -2,5 +2,6 @@
   <%= mltop_nav do |nav| %>
     <% nav.section "Tasks", admin_tasks_path, condition: [ "admin/tasks" ] %>
     <% nav.section "Test sets", admin_test_sets_path, condition: [ "admin/test_sets" ] %>
+    <% nav.section "Evaluators", admin_evaluators_path, condition: [ "admin/evaluators" ] %>
   <% end %>
 </div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -72,3 +72,22 @@ crumb :edit_admin_task do |task|
   link "Edit", edit_admin_task_path(task)
   parent :admin_task, task
 end
+
+crumb :admin_evaluators do
+  link "Manage evaluators", admin_evaluators_path
+end
+
+crumb :admin_evaluator do |evaluator|
+  link evaluator, admin_evaluator_path(evaluator)
+  parent :admin_evaluators
+end
+
+crumb :new_admin_evaluator do
+  link "New", new_admin_evaluator_path
+  parent :admin_evaluators
+end
+
+crumb :edit_admin_evaluator do |evaluator|
+  link "Edit", edit_admin_evaluator_path(evaluator)
+  parent :admin_evaluator, evaluator
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :tasks
     resources :test_sets
+    resources :evaluators
   end
 
   get "up" => "rails/health#show", as: :rails_health_check

--- a/test/controllers/admin/evaluations_controller_test.rb
+++ b/test/controllers/admin/evaluations_controller_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class Admin::EvaluatorsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in_as("marek")
+  end
+
+  test "should get index" do
+    get admin_evaluators_path
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_admin_evaluator_path
+    assert_response :success
+  end
+
+  test "should create new evaluator" do
+    assert_difference("Evaluator.count") do
+      post admin_evaluators_url, params: { evaluator: {
+        name: "New evaluator name"
+      } }
+    end
+
+    assert_redirected_to admin_evaluator_path(Evaluator.last)
+  end
+
+  test "should show evaluator" do
+    evaluator = evaluators(:sacrebley)
+
+    get admin_evaluator_path(evaluator)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    evaluator = evaluators(:sacrebley)
+
+    get edit_admin_evaluator_path(evaluator)
+    assert_response :success
+  end
+
+  test "should update evaluator" do
+    evaluator = evaluators(:sacrebley)
+
+    patch admin_evaluator_path(evaluator), params: { evaluator: { name: "updated name" } }
+    assert_redirected_to admin_evaluator_path(evaluator)
+    assert_equal "updated name", evaluator.reload.name
+  end
+
+  test "should destroy evaluator" do
+    evaluator = evaluators(:sacrebley)
+
+    assert_difference("Evaluator.count", -1) do
+      delete admin_evaluator_path(evaluator)
+    end
+
+    assert_redirected_to admin_evaluators_path
+  end
+end


### PR DESCRIPTION
Very basic CRUD for evaluators. This needs to be extended by providing site-specific information related to running evaluations (such as site, slurm starting script, a nice description of which parameters will be passed to the script, etc.). It also does not contain a section for managing metrics. This will be done in the following PR.