### PR TITLE
Use overmind if available instead of foreman

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -3,8 +3,6 @@
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 
-# Let the debug gem allow remote connections,
-# but avoid loading until `debugger` is called
 
 if command -v overmind foo >/dev/null 2>&1; then
   exec overmind start -f Procfile.dev "$@"


### PR DESCRIPTION
Debugging with `rdbg -A` and foreman is awful. I have to execute every call 2 times (first one fails idk why), server gets super slow and I don't have access to everything. I added overmind to dev so if someone has it installed, it takes precedence. If you want to use foreman, you are still able to do so