### PR TITLE
Simple UI for managing evaluator metrics

### DIFF
--- a/app/controllers/admin/evaluators/metrics_controller.rb
+++ b/app/controllers/admin/evaluators/metrics_controller.rb
@@ -1,0 +1,56 @@
+module Admin
+  module Evaluators
+    class MetricsController < ApplicationController
+      before_action :set_evaluator, only: %i[ new create ]
+      before_action :set_metric, only: %i[ edit update destroy ]
+
+      def new
+        @metric = @evaluator.metrics.build
+      end
+
+      def create
+        @metric = @evaluator.metrics.build(metric_params)
+        if @metric.save
+          flash.now[:notice] = "Evaluator metric was successfully created."
+        else
+          render :new, status: :unprocessable_entity
+        end
+      end
+
+      def edit
+      end
+
+      def update
+        if @metric.update(metric_params)
+          redirect_to admin_evaluator_path(@metric.evaluator),
+            notice: "Evaluator metric was successfully updated."
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        if @metric.destroy
+          redirect_to admin_evaluator_path(@metric.evaluator),
+            notice:  "\"#{@metric.name}\" metric was sucessfully deleted."
+        else
+          redirect_to admin_evaluator_path(@metric.evaluator),
+            alert: "Unable to delete \"#{@metric.name}\" metric."
+        end
+      end
+
+      private
+        def set_evaluator
+          @evaluator = Evaluator.find(params[:evaluator_id])
+        end
+
+        def set_metric
+          @metric = Metric.find(params[:id])
+        end
+
+        def metric_params
+          params.require(:metric).permit(:name)
+        end
+    end
+  end
+end

--- a/app/views/admin/evaluators/_metric.html.erb
+++ b/app/views/admin/evaluators/_metric.html.erb
@@ -1,0 +1,21 @@
+<%# locals: (metric:) %>
+
+<%= turbo_frame_tag metric do %>
+  <div class="sm:flex sm:items-start sm:justify-between">
+    <span><%= metric.name %></span>
+    <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center space-x-2">
+      <%= link_to "Edit", edit_admin_metric_path(metric), class: "btn btn-warning" %>
+      <%= button_to "Delete", admin_metric_path(metric), class: "btn btn-danger", method: :delete, 
+          form: { "data-turbo-confirm": "Are you sure you want to remove \"#{metric.name}\" metric?",
+                  "data-turbo-frame": "_top" }
+      %>
+    </div>
+  </div>
+<% end %>
+
+<div class="relative py-3">
+  <div class="absolute inset-0 flex items-center" aria-hidden="true">
+    <div class="w-full border-t border-gray-300"></div>
+  </div>
+</div>
+

--- a/app/views/admin/evaluators/_new_metric.html.erb
+++ b/app/views/admin/evaluators/_new_metric.html.erb
@@ -1,0 +1,5 @@
+<%# locals: (evaluator:) %>
+
+<%= turbo_frame_tag "new_metric" do %>
+  <%= link_to "New metric", new_admin_evaluator_metric_path(evaluator), class: "btn btn-primary" %>
+<% end %>

--- a/app/views/admin/evaluators/metrics/_form.html.erb
+++ b/app/views/admin/evaluators/metrics/_form.html.erb
@@ -1,0 +1,27 @@
+
+<%# locals: (metric:, url: [:admin, metric.evaluator, metric]) %>
+
+<%= form_with(model: metric, url:, class: "contents") do |form| %>
+  <% if metric.errors.any? %>
+    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
+      <h2><%= pluralize(metric.errors.count, "error") %> prohibited this evaluator from being saved:</h2>
+
+      <ul>
+        <% metric.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="space-y-12">
+    <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+      <%= form.text_field :name, wrapper: "sm:col-span-4" %>
+    </div>
+  </div>
+
+  <div class="mt-6 flex items-center justify-end gap-x-6">
+    <%= link_to "Cancel", :back, class: "btn btn-primary" %>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/evaluators/metrics/create.turbo_stream.erb
+++ b/app/views/admin/evaluators/metrics/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.prepend "flash", partial: "layouts/flash" %>
+<%= turbo_stream.append  "metrics", partial: "admin/evaluators/metric", locals: { metric: @metric } %>
+<%= turbo_stream.replace "new_metric", partial: "admin/evaluators/new_metric", locals: { evaluator: @metric.evaluator } %>

--- a/app/views/admin/evaluators/metrics/edit.html.erb
+++ b/app/views/admin/evaluators/metrics/edit.html.erb
@@ -1,0 +1,5 @@
+<%= mltop_title "Edit evaluator metric" %>
+
+<%= turbo_frame_tag @metric, target: "_top" do %>
+  <%= render "form", metric: @metric, url: admin_metric_path(@metric) %>
+<% end %>

--- a/app/views/admin/evaluators/metrics/new.html.erb
+++ b/app/views/admin/evaluators/metrics/new.html.erb
@@ -1,0 +1,5 @@
+<%= mltop_title "New evaluator metric" %>
+
+<%= turbo_frame_tag "new_metric" do %>
+    <%= render "form", metric: @metric %>
+<% end %>

--- a/app/views/admin/evaluators/show.html.erb
+++ b/app/views/admin/evaluators/show.html.erb
@@ -13,4 +13,20 @@
       </div>
     </div>
   </div>
+
+  <div class="mt-6 border-t border-gray-100">
+    <dl class="divide-y divide-gray-100">
+      <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+        <dt class="text-sm font-medium leading-6 text-gray-900">
+          Metrics
+        </dt>
+        <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+          <div id="metrics">
+            <%= render partial: "metric", collection: @evaluator.metrics, as: :metric %>
+          </div>
+          <%= render "new_metric", evaluator: @evaluator %>
+        </dd>
+      </div>
+    </dl>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,11 +23,10 @@ Rails.application.routes.draw do
       resources :test_sets, only: [ :new, :create ], module: :tasks
     end
     resources :test_sets do
-      resources :entries, only: :index, module: :test_sets
-    end
-    resources :evaluators
-    resources :test_sets do
       resources :entries, module: :test_sets, shallow: true, except: [ :show ]
+    end
+    resources :evaluators do
+      resources :metrics, module: :evaluators, shallow: true, except: [ :index, :show ]
     end
   end
 

--- a/test/controllers/admin/evaluations/metrics_controller_test.rb
+++ b/test/controllers/admin/evaluations/metrics_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class Admin::Evaluators::MetricsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in_as("marek")
+  end
+
+  test "should get new" do
+    get new_admin_evaluator_metric_path(evaluators("sacrebleu"))
+    assert_response :success
+  end
+
+  test "should create new evaluator" do
+    evaluator = evaluators("sacrebleu")
+    assert_difference("evaluator.metrics.count") do
+      post admin_evaluator_metrics_path(evaluator, format: :turbo_stream), params: { metric: {
+        name: "new-metric"
+      } }
+    end
+
+    assert_response :success
+  end
+
+  test "should get edit" do
+    metric = metrics(:blue)
+
+    get edit_admin_metric_path(metric)
+    assert_response :success
+  end
+
+  test "should update metric" do
+    metric = metrics(:blue)
+
+    patch admin_metric_path(metric), params: { metric: { name: "updated-name" } }
+    assert_redirected_to admin_evaluator_path(metric.evaluator)
+    assert_equal "updated-name", metric.reload.name
+  end
+
+  test "should destroy metric" do
+    metric = metrics(:blue)
+
+    assert_difference("Metric.count", -1) do
+      delete admin_metric_path(metric)
+    end
+
+    assert_redirected_to admin_evaluator_path(metric.evaluator)
+  end
+end


### PR DESCRIPTION
Fundamental UI for managing metrics. All the metrics operations can be done from the evaluator's show view.

There is one ugly element I don't like: opening a new metric form is done through turbo frame, but after the metric is created, I'm doing a full page reload. The problem is that frame attributes are not updated when updating turbo frame content. As a result, a new turbo frame is added to the new view with `data-turbo-frame: "_top"` to have the full page reloaded after the record is created.

For now, I'm intentionally not using turbo streams (or more sophisticated solutions) to keep it as simple as possible.

Fixes #85