### PR TITLE
Turn off turbo on login

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -29,7 +29,7 @@
           <% if signed_in? %>
             <%= button_to "Log out", sign_out_path, method: :delete, class: "btn btn-primary" %>
           <% else %>
-            <%= link_to "Log in", sign_in_path, type:"button", class: "btn btn-primary", "data-turbo-prefetch": false %>
+            <%= link_to "Log in", sign_in_path, type:"button", class: "btn btn-primary", "data-turbo": false %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
Our SSO does not support cors request done to fetch content by turbo. As a result failed request is done at the beginning and only then normal http get request. To solve this issue turbo was turned off on login button.