### PR TITLE
Remove flash message when faded

### DIFF
--- a/app/javascript/controllers/autoremove_controller.js
+++ b/app/javascript/controllers/autoremove_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    interval: Number
+  }
+
+  #timer
+
+  connect() {
+    this.#scheduleRemoval();
+  }
+
+  disconnect() {
+    this.#resetTimer()
+  }
+
+  remove() {
+    console.log("removing")
+    this.element.remove()
+  }
+
+  // Private
+
+  #scheduleRemoval() {
+    if (!!this.intervalValue) {
+      this.#timer = setTimeout(() => this.remove(), this.intervalValue * 1000)
+    }
+  }
+
+  #resetTimer() {
+    if(!!this.#timer) {
+      clearTimeout(this.#timer)
+      this.#timer = null
+    }
+
+  }
+}

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,10 +1,6 @@
-<%= turbo_frame_tag "flash" do %>
-  <div aria-live="assertive" class="flash-container pointer-events-none px-4 py-4 space-y-4 fixed inset-0 items-end">
-      <% if notice.present? %>
-        <%= render "layouts/flash/message", text: notice, type: "notice" %>
-      <% end%>
-      <% if alert.present? %>
-        <%= render "layouts/flash/message", text: alert, type: "alert" %>
-      <% end %>
-  </div>
+<% if notice.present? %>
+  <%= render "layouts/flash/message", text: notice, type: "notice" %>
 <% end%>
+<% if alert.present? %>
+  <%= render "layouts/flash/message", text: alert, type: "alert" %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,9 @@
     <%= render "layouts/navbar" %>
     <main class="container mx-auto mt-5">
       <%= render "layouts/breadcrumbs" %>
-      <%= render "layouts/flash" %>
+      <div id="flash" aria-live="assertive" class="text-center pointer-events-none px-4 py-4 space-y-4 fixed inset-0 items-end">
+        <%= render "layouts/flash" %>
+      </div>
       <%= yield %>
     </main>
     <%= render "layouts/footer" %>

--- a/app/views/layouts/flash/_message.html.erb
+++ b/app/views/layouts/flash/_message.html.erb
@@ -1,4 +1,4 @@
-  <div class="flex w-full flex-col items-center sm:items-end">
+  <div class="flex w-full flex-col items-center sm:items-end animate-appear-then-fade" data-controller="autoremove" data-autoremove-interval-value="6">
     <div class="pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5">
       <div class="p-4">
         <div class="flex items-start">


### PR DESCRIPTION
The Stimulus `autoremove` controller removes the flash message after it has faded. The interval is synchronized with the `animate-appear-then-face` tailwind utility class (6 seconds).

fixes #127