### PR TITLE
show form errors next to proper field

### DIFF
--- a/app/views/admin/evaluators/_form.html.erb
+++ b/app/views/admin/evaluators/_form.html.erb
@@ -1,18 +1,6 @@
 <%# locals: (evaluator:) %>
 
 <%= form_with(model: evaluator, url: [:admin, evaluator], class: "contents") do |form| %>
-  <% if evaluator.errors.any? %>
-    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
-      <h2><%= pluralize(evaluator.errors.count, "error") %> prohibited this evaluator from being saved:</h2>
-
-      <ul>
-        <% evaluator.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
   <div class="space-y-12">
     <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
       <%= form.text_field :name, wrapper: "sm:col-span-4" %>

--- a/app/views/admin/evaluators/metrics/_form.html.erb
+++ b/app/views/admin/evaluators/metrics/_form.html.erb
@@ -2,18 +2,6 @@
 <%# locals: (metric:, url: [:admin, metric.evaluator, metric]) %>
 
 <%= form_with(model: metric, url:, class: "contents") do |form| %>
-  <% if metric.errors.any? %>
-    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
-      <h2><%= pluralize(metric.errors.count, "error") %> prohibited this evaluator from being saved:</h2>
-
-      <ul>
-        <% metric.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
   <div class="space-y-12">
     <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
       <%= form.text_field :name, wrapper: "sm:col-span-4" %>

--- a/app/views/admin/tasks/_form.html.erb
+++ b/app/views/admin/tasks/_form.html.erb
@@ -1,18 +1,6 @@
 <%# locals: (task:) %>
 
 <%= form_with(model: task, url: [:admin, task], class: "contents") do |form| %>
-  <% if task.errors.any? %>
-    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
-      <h2><%= pluralize(task.errors.count, "error") %> prohibited this task from being saved:</h2>
-
-      <ul>
-        <% task.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
   <div class="space-y-12">
     <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
       <%= form.text_field :name, wrapper: "sm:col-span-4" %>

--- a/app/views/admin/test_sets/_form.html.erb
+++ b/app/views/admin/test_sets/_form.html.erb
@@ -1,18 +1,6 @@
 <%# locals: (test_set:) %>
 
 <%= form_with(model: test_set, url: [:admin, test_set], class: "contents") do |form| %>
-
-  <% if test_set.errors.any? %>
-    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
-      <h2><%= pluralize(test_set.errors.count, "error") %> prohibited this test_set from being saved:</h2>
-      <ul>
-        <% test_set.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
   <div class="space-y-12">
     <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
       <%= form.text_field :name, wrapper: "sm:col-span-4" %>

--- a/app/views/admin/test_sets/entries/_form.html.erb
+++ b/app/views/admin/test_sets/entries/_form.html.erb
@@ -1,20 +1,8 @@
 <%= turbo_frame_tag dom_id(test_set, "add_entry") do %>
-
-    <% if test_set_entry.errors.any? %>
-      <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
-        <h2><%= pluralize(test_set_entry.errors.count, "error") %> prohibited this test set entry from being saved:</h2>
-        <ul>
-          <% test_set_entry.errors.each do |error| %>
-            <li><%= error.full_message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
-
   <%= form_with(model: test_set_entry, url: [:admin, test_set_entry]) do |form| %>
       <%= form.select :source_language, Mltop::LANGUAGES, wrapper: "sm:col-span-1" %>
       <%= form.select :target_language, Mltop::LANGUAGES, wrapper: "sm:col-span-1" %>
-      <%= form.collection_select :task_id, Task.all, :id, :name, {}, class: "sm:col-span-1" %>
+      <%= form.collection_select :task_id, Task.all, :id, :name, {}, include_blank: false, class: "sm:col-span-1" %>
       <div class="mt-2">
         <label for="test_set_entry_input"> Input </label>
         <%= form.file_field :input %>
@@ -28,5 +16,4 @@
         <%= form.submit %>
       </div>
   <% end %>
-
 <% end %>

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -1,18 +1,6 @@
 <%# locals: (model:) %>
 
 <%= form_with(model:, url:model.new_record? ? submissions_path : submission_path(@model), class: "contents") do |form| %>
-  <% if model.errors.any? %>
-    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
-      <h2><%= pluralize(model.errors.count, "error") %> prohibited this task from being saved:</h2>
-
-      <ul>
-        <% model.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
   <div class="space-y-12">
     <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
       <%= form.text_field :name, wrapper: "col-span-full" %>
@@ -21,7 +9,7 @@
       <fieldset>
         <legend class="text-sm font-semibold leading-6 text-gray-900">Compatibility map</legend>
         <div class="mt-6 space-y-6">
-          <%= form.collection_check_boxes :task_ids, @tasks, :id, :to_s do |b| %>
+          <%= form.collection_check_boxes :task_models, @tasks, :id, :to_s do |b| %>
             <div class="relative flex gap-x-3">
               <div class="flex h-6 items-center">
                 <%= b.check_box %>


### PR DESCRIPTION
Shows error label next to a form field when model returns an error
in checkbox select it's shown before the field, because if there's many checkboxes, it can get lost. it's also closer to label that way