### PR TITLE
add inversed_scoring to metric, adjust leaderboards color based on it

### DIFF
--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -16,9 +16,9 @@ module TasksHelper
       metric == selected_metric && test_set == selected_test_set
     end
 
-  def interpolate_color(metric_value, inversed_scoring = false)
+  def interpolate_color(metric_value, metric)
       value = metric_value ? [ 0, [ 100, metric_value ].min ].max : 0
-      value = 100 - value if inversed_scoring
+      value = 100 - value if metric.asc?
       red = [ 255, 0, 0 ]
       yellow = [ 255, 255, 0 ]
       green = [ 0, 255, 0 ]

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -3,4 +3,9 @@ class Metric < ApplicationRecord
   has_many :scores, dependent: :destroy
 
   validates :name, presence: true
+
+  enum :order, {
+    asc: 0,
+    desc: 1
+  }
 end

--- a/app/models/top/rows.rb
+++ b/app/models/top/rows.rb
@@ -9,6 +9,8 @@ class Top::Rows
     if test_set && metric
       rows = @rows.sort do |a, b|
         a, b = b, a if order == "desc"
+        a, b = b, a if metric.asc?
+
         a.score(test_set:, metric:, test_set_entry:).value <=>
           b.score(test_set:, metric:, test_set_entry:).value
       end

--- a/app/views/models/_scores.html.erb
+++ b/app/views/models/_scores.html.erb
@@ -36,7 +36,7 @@
           <% @model_row.target_languages.each do |target_language| %>
             <%- score = @model_row.score(source_language, target_language) -%>
               <td class="score-cell"
-                style="background-color: <%= interpolate_color(score, @metric.inversed_scoring) unless score.nil? %>">
+                style="background-color: <%= interpolate_color(score, @metric) unless score.nil? %>">
               <%= score && number_with_precision(score, precision: 2) %>
             </td>
           <% end %>

--- a/app/views/tasks/leaderboards/_leaderboard.html.erb
+++ b/app/views/tasks/leaderboards/_leaderboard.html.erb
@@ -33,7 +33,7 @@
         <% task.test_sets.each do |test_set| %>
           <% task.metrics.each do |metric| %>
             <%- value = row.score(test_set:, metric:).value %>
-            <td class="score-cell" style="background-color: <%= interpolate_color(value, metric.inversed_scoring) %>">
+            <td class="score-cell" style="background-color: <%= interpolate_color(value, metric) %>">
               <%= number_with_precision value, precision: 2 %>
             </td>
           <% end %>

--- a/app/views/test_sets/leaderboards/_leaderboard.html.erb
+++ b/app/views/test_sets/leaderboards/_leaderboard.html.erb
@@ -40,7 +40,7 @@
 
         <% task.metrics.each do |metric| %>
           <%- value = row.score(test_set: test_set, metric:).value %>
-          <td class="score-cell" style="background-color: <%= interpolate_color(value, metric.inversed_scoring) %>">
+          <td class="score-cell" style="background-color: <%= interpolate_color(value, metric) %>">
             <%= number_with_precision value, precision: 2 %>
           </td>
         <% end %>
@@ -48,7 +48,7 @@
         <% @test_set_entries.each do |test_set_entry| %>
           <% task.metrics.each do |metric| %>
             <%- value = row.score(test_set: test_set, metric:, test_set_entry:).value %>
-            <td class="score-cell" style="background-color: <%= interpolate_color(value, metric.inversed_scoring) %>">
+            <td class="score-cell" style="background-color: <%= interpolate_color(value, metric) %>">
               <%= number_with_precision value, precision: 2 %>
             </td>
           <% end %>

--- a/db/data/evaluators.yml
+++ b/db/data/evaluators.yml
@@ -26,9 +26,12 @@ screbleu:
     fi
   host: ares.cyfronet.pl
   metrics:
-    - bleu
-    - chrf
-    - ter
+    - name: bleu
+      order: desc
+    - name: chrf
+      order: desc
+    - name: ter
+      order: asc
   tasks:
     - MT
     - ST
@@ -62,7 +65,8 @@ blueurt:
     fi
   host: athena.cyfronet.pl
   metrics:
-    - bleurt
+    - name: bleurt
+      order: desc
   tasks:
     - MT
     - ST
@@ -95,7 +99,8 @@ wer:
     fi
   host: ares.cyfronet.pl
   metrics:
-    - wer
+    - name: wer
+      order: asc
   tasks:
    - MT
    - ST
@@ -130,7 +135,8 @@ rogue:
     fi
   host: ares.cyfronet.pl
   metrics:
-    - rouge
+    - name: rouge
+      order: desc
   tasks:
     - SUM
     - SSUM
@@ -164,7 +170,8 @@ accuracy:
     fi
   host: ares.cyfronet.pl
   metrics:
-    - accuracy
+    - name: accuracy
+      order: desc
   tasks:
     - SQA
 
@@ -197,7 +204,8 @@ exact-match:
     fi
   host: ares.cyfronet.pl
   metrics:
-    - exact-match
+    - name: exact-match
+      order: desc
   tasks:
     - ASR
     - LIPREAD
@@ -231,6 +239,7 @@ f1-score:
     fi
   host: ares.cyfronet.pl
   metrics:
-    - f1-score
+    - name: f1-score
+      order: desc
   tasks:
     - SQA

--- a/db/migrate/20241120131301_add_inversed_scoring_to_metric.rb
+++ b/db/migrate/20241120131301_add_inversed_scoring_to_metric.rb
@@ -1,5 +1,5 @@
 class AddInversedScoringToMetric < ActiveRecord::Migration[8.0]
   def change
-    add_column :metrics, :inversed_scoring, :boolean, default: false, null: false
+    add_column :metrics, :order, :integer, default: 1, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,7 +92,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_20_131301) do
     t.bigint "evaluator_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "inversed_scoring", default: false, null: false
+    t.integer "order", default: 1, null: false
     t.index ["evaluator_id"], name: "index_metrics_on_evaluator_id"
   end
 

--- a/test/fixtures/metrics.yml
+++ b/test/fixtures/metrics.yml
@@ -1,16 +1,19 @@
 blue:
   name: blue
+  order: desc
   evaluator: sacrebleu
 
 chrf:
   name: chrf
+  order: desc
   evaluator: sacrebleu
 
 ter:
   name: ter
+  order: asc
   evaluator: sacrebleu
-  inversed_scoring: true
 
 blueurt:
   name: blueurt
+  order: desc
   evaluator: blueurt

--- a/test/models/top/row_test.rb
+++ b/test/models/top/row_test.rb
@@ -85,12 +85,31 @@ class Top::RowTest < ActiveSupport::TestCase
                                             test_set_entry: test_set_entries(:flores_st_en_pl), order: :asc).map(&:model)
   end
 
+  test "order with metric asc order" do
+    m1 = create(:model, name: "model 1", tasks: [ tasks(:st) ])
+    m2 = create(:model, name: "model 2", tasks: [ tasks(:st) ])
+    m3 = create(:model, name: "model 3", tasks: [ tasks(:st) ])
+
+    new_evaluation(m1, :flores_st_en_pl, 1, evaluator: evaluators(:sacrebleu), metric: metrics(:ter))
+    new_evaluation(m2, :flores_st_en_pl, 3, evaluator: evaluators(:sacrebleu), metric: metrics(:ter))
+    new_evaluation(m3, :flores_st_en_pl, 2, evaluator: evaluators(:sacrebleu), metric: metrics(:ter))
+
+    rows = Top::Row.where(task: tasks(:st))
+
+    assert_equal [ m1, m3, m2 ], rows.order(test_set: test_sets(:flores),
+                                            metric: metrics(:ter),
+                                            test_set_entry: test_set_entries(:flores_st_en_pl)).map(&:model)
+
+    assert_equal [ m2, m3, m1 ], rows.order(test_set: test_sets(:flores),
+                                            metric: metrics(:ter),
+                                            test_set_entry: test_set_entries(:flores_st_en_pl), order: :asc).map(&:model)
+  end
+
   private
-    def new_evaluation(model, test_set_entry_fixture_name, value)
+    def new_evaluation(model, test_set_entry_fixture_name, value, evaluator: evaluators(:blueurt), metric: metrics(:blueurt))
       hypothesis = create(:hypothesis, model:,
                           test_set_entry: test_set_entries(test_set_entry_fixture_name))
-      evaluation = create(:evaluation, hypothesis:,
-                          evaluator: evaluators(:blueurt))
-      create(:score, evaluation:, metric: metrics(:blueurt), value:)
+      evaluation = create(:evaluation, hypothesis:, evaluator:)
+      create(:score, evaluation:, metric:, value:)
     end
 end


### PR DESCRIPTION
Some of the metrics are inversed, meaning that 0 is the highest possible score.

- Add `order` enum to `Metric` with `asc` and `desc` as possible values
- Add argument in interpolate_color to reverse it if required
- Respect order while showing ranking


Fixes #135