### PR TITLE
fix compatibility map in submission form

### DIFF
--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -10,7 +10,7 @@ class Model < ApplicationRecord
   has_rich_text :description
 
   validates :name, presence: true
-  validates :task_models, presence: true
+  validates :task_ids, presence: true
 
   def to_s
     name

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -9,7 +9,7 @@
       <fieldset>
         <legend class="text-sm font-semibold leading-6 text-gray-900">Compatibility map</legend>
         <div class="mt-6 space-y-6">
-          <%= form.collection_check_boxes :task_models, @tasks, :id, :to_s do |b| %>
+          <%= form.collection_check_boxes :task_ids, @tasks, :id, :to_s do |b| %>
             <div class="relative flex gap-x-3">
               <div class="flex h-6 items-center">
                 <%= b.check_box %>


### PR DESCRIPTION
`task_models` would not mark checkboxes in model form