### PR TITLE
Only published test sets are visible

### DIFF
--- a/app/controllers/admin/test_sets_controller.rb
+++ b/app/controllers/admin/test_sets_controller.rb
@@ -48,7 +48,7 @@ class Admin::TestSetsController < Admin::ApplicationController
 
   private
     def test_set_params
-      params.required(:test_set).permit(:name, :description)
+      params.required(:test_set).permit(:name, :description, :published)
     end
 
     def find_test_set

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -11,7 +11,7 @@ class ModelsController < ApplicationController
     @tasks = @model.tasks
     @task = find_by_query_param(@tasks, :tid)
 
-    @test_sets = @task.test_sets
+    @test_sets = @task.test_sets.published
     @metrics = @task.metrics
 
     @test_set = find_by_query_param(@test_sets, :tsid)

--- a/app/controllers/submissions/tasks_controller.rb
+++ b/app/controllers/submissions/tasks_controller.rb
@@ -8,7 +8,7 @@ class Submissions::TasksController < ApplicationController
 
   def show
     @model = Current.user.models.find(params[:submission_id])
-    @task = @model.tasks.find(params[:id])
+    @task = @model.tasks.with_published_test_sets.find(params[:id])
     @evaluators = @task.evaluators
   end
 

--- a/app/controllers/tasks/leaderboards_controller.rb
+++ b/app/controllers/tasks/leaderboards_controller.rb
@@ -9,7 +9,7 @@ class Tasks::LeaderboardsController < ApplicationController
   end
 
   def show
-    @task = Task.includes(:test_sets, :metrics).find(params[:task_id])
+    @task = Task.with_published_test_sets.includes(:metrics).find(params[:task_id])
     @rows = Top::Row
       .where(task: @task)
       .order(test_set: selected_test_set, metric: selected_metric, order: selected_order)
@@ -25,6 +25,6 @@ class Tasks::LeaderboardsController < ApplicationController
     end
 
     def selected_test_set
-      @test_set ||= TestSet.find_by(id: params[:tsid]) if params[:tsid].present?
+      @test_set ||= TestSet.published.find_by(id: params[:tsid]) if params[:tsid].present?
     end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,7 +9,7 @@ class TasksController < ApplicationController
   end
 
   def show
-    @task = Task.includes(:test_sets).find(params[:id])
+    @task = Task.with_published_test_sets.find(params[:id])
   end
 
   private

--- a/app/controllers/test_sets_controller.rb
+++ b/app/controllers/test_sets_controller.rb
@@ -2,11 +2,11 @@ class TestSetsController < ApplicationController
   allow_unauthenticated_access
 
   def index
-    @test_sets = TestSet.includes(:tasks).all
+    @test_sets = TestSet.includes(:tasks).published
   end
 
   def show
-    @test_set = TestSet.find(params[:id])
+    @test_set = TestSet.published.find(params[:id])
     @tasks = @test_set.tasks
   end
 end

--- a/app/models/model/task_evaluation.rb
+++ b/app/models/model/task_evaluation.rb
@@ -5,7 +5,7 @@ class Model::TaskEvaluation
   end
 
   def test_set_evaluations
-    @task.test_sets.includes(:entries)
+    @task.test_sets.published.includes(:entries)
       .map { |ts| TestSetEvaluation.new(@model, ts) }
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -22,6 +22,9 @@ class Task < ApplicationRecord
   enum :from, TYPES, prefix: true
   enum :to, TYPES, prefix: true
 
+  scope :with_published_test_sets,
+        -> { includes(:test_sets).where(test_sets: { published: true }) }
+
   def to_s
     "#{name} (#{slug})"
   end

--- a/app/models/test_set.rb
+++ b/app/models/test_set.rb
@@ -12,6 +12,8 @@ class TestSet < ApplicationRecord
 
   validates :name, presence: true
 
+  scope :published, -> { where(published: true) }
+
   def source_languages_for(task:)
     entries.where(task:).pluck(:source_language).uniq.sort
   end

--- a/app/views/admin/tasks/show.html.erb
+++ b/app/views/admin/tasks/show.html.erb
@@ -33,7 +33,10 @@
       <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
         <dt class="text-sm font-medium leading-6 text-gray-900">Test sets</dt>
         <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
-          <%= @task.test_sets.map(&:name).join(", ") %>
+          <%= @task.test_sets
+                .map { |ts| "#{ts.name}#{"(invisible)" unless ts.published}" }
+                .join(", ")
+          %>
         </dd>
       </div>
       <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">

--- a/app/views/admin/test_sets/_form.html.erb
+++ b/app/views/admin/test_sets/_form.html.erb
@@ -5,6 +5,11 @@
     <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
       <%= form.text_field :name, wrapper: "sm:col-span-4" %>
       <%= form.rich_text_area :description, wrapper: "col-span-full", class: "h-96" %>
+      <div class="relative flex gap-x-3">
+        <div class="flex h-6 items-center">
+          <%= form.check_box :published %>
+        </div>
+      </div>
   </div>
 
   <div class="mt-6 flex items-center justify-end gap-x-6">

--- a/app/views/admin/test_sets/show.html.erb
+++ b/app/views/admin/test_sets/show.html.erb
@@ -27,6 +27,12 @@
           </dd>
       </div>
       <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+          <dt class="text-sm font-medium leading-6 text-gray-900">Published</dt>
+          <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+            <%= @test_set.published %>
+          </dd>
+      </div>
+      <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
         <dt class="text-sm font-medium leading-6 text-gray-900">Test set entries</dt>
         <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
         <%= turbo_frame_tag dom_id(@test_set, "entries_table") do %>

--- a/db/migrate/20241204112854_add_published_to_test_set.rb
+++ b/db/migrate/20241204112854_add_published_to_test_set.rb
@@ -1,0 +1,5 @@
+class AddPublishedToTestSet < ActiveRecord::Migration[8.0]
+  def change
+    add_column :test_sets, :published, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_20_131301) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_04_112854) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -161,6 +161,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_20_131301) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "published", default: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/task_loader/processor.rb
+++ b/lib/task_loader/processor.rb
@@ -1,4 +1,6 @@
 class TaskLoader::Processor
+  RESTRICTED_TEST_SETS = %w[ MUSTC MTEDX LRS2 LRS3 ].freeze
+
   attr_reader :dir
 
   def initialize(dir)
@@ -45,7 +47,7 @@ class TaskLoader::Processor
 
     def language_process(dir, &block)
       name = dir.basename.to_s
-      test_set = test_sets(name)
+      test_set = test_sets(name, published: !RESTRICTED_TEST_SETS.include?(name.upcase))
 
       dir.each_child do |entry|
         next if entry.file?
@@ -62,9 +64,12 @@ class TaskLoader::Processor
       error "Test set #{entry.basename} not supported yet for #{slug}"
     end
 
-    def test_sets(name)
+    def test_sets(name, published:)
       TestSet.find_or_create_by!(name:) do |ts|
-        ts.description = "TODO: please update test set description"
+        ts.assign_attributes(
+          description: "TODO: please update test set description",
+          published:
+        )
       end
     end
 

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -30,6 +30,16 @@ flores_st_pl_en_groundtruth:
   record: flores_st_pl_en (TestSetEntry)
   blob: flores_st_pl_en_groundtruth_blob
 
+unpublished_st_pl_en_input:
+  name: input
+  record: unpublished_st_pl_en (TestSetEntry)
+  blob: unpublished_st_pl_en_input_blob
+
+unpublished_st_pl_en_groundtruth:
+  name: groundtruth
+  record: unpublished_st_pl_en (TestSetEntry)
+  blob: unpublished_st_pl_en_groundtruth_blob
+
 
 flores_asr_en_pl_input:
   name: input

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -7,6 +7,9 @@ flores_st_en_it_groundtruth_blob: <%= ActiveStorage::FixtureSet.blob filename: "
 flores_st_pl_en_input_blob: <%= ActiveStorage::FixtureSet.blob filename: "input.txt" %>
 flores_st_pl_en_groundtruth_blob: <%= ActiveStorage::FixtureSet.blob filename: "input.txt" %>
 
+unpublished_st_pl_en_input_blob: <%= ActiveStorage::FixtureSet.blob filename: "input.txt" %>
+unpublished_st_pl_en_groundtruth_blob: <%= ActiveStorage::FixtureSet.blob filename: "input.txt" %>
+
 flores_asr_en_pl_input_blob: <%= ActiveStorage::FixtureSet.blob filename: "input.txt" %>
 flores_asr_en_pl_groundtruth_blob: <%= ActiveStorage::FixtureSet.blob filename: "input.txt" %>
 

--- a/test/fixtures/test_set_entries.yml
+++ b/test/fixtures/test_set_entries.yml
@@ -16,6 +16,12 @@ flores_st_pl_en:
   source_language: pl
   target_language: en
 
+unpublished_st_pl_en:
+  task: st
+  test_set: unpublished
+  source_language: pl
+  target_language: en
+
 
 flores_asr_en_pl:
   task: asr

--- a/test/fixtures/test_sets.yml
+++ b/test/fixtures/test_sets.yml
@@ -1,5 +1,11 @@
 flores:
   name: FLORES
+  published: true
 
 mustc:
   name: MUSTC
+  published: true
+
+unpublished:
+  name: Unpublished - should not be visible
+  published: false

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,4 +1,9 @@
 require "test_helper"
 
 class TaskTest < ActiveSupport::TestCase
+  test "#with_published_test_sets" do
+    st = Task.with_published_test_sets.find(tasks(:st).id)
+
+    assert_equal test_sets(:flores, :mustc), st.test_sets.to_a
+  end
 end

--- a/test/models/test_set_test.rb
+++ b/test/models/test_set_test.rb
@@ -27,4 +27,10 @@ class TestSetTest < ActiveSupport::TestCase
     assert_equal 3, entries.size
     assert_equal test_set_entries("flores_st_en_pl", "flores_st_en_it", "flores_st_pl_en"), entries
   end
+
+  test "get all published test sets" do
+    published = TestSet.published
+
+    assert_equal test_sets(:flores, :mustc).sort, published
+  end
 end


### PR DESCRIPTION
Due to legal constraints, we cannot show some of the test sets to the users. As a result `published` boolean value was added to the test set. Only published test sets are visible to the users.

Fixes #143