### PR TITLE
Not Meetween PLGrid users can login, but cannot start the evaluations

### DIFF
--- a/app/models/plgrid/user.rb
+++ b/app/models/plgrid/user.rb
@@ -9,12 +9,15 @@ module Plgrid
     attr_reader :uid
 
     def initialize(auth)
-      fetch_short_lived_ssh_credentials!(auth.dig("credentials", "token"))
       @uid = auth.uid
       @teams= auth.dig("extra", "raw_info", "groups") || []
       @name = auth.info["name"]
       @email = auth.info["email"]
       @plgrid_login = auth.info["nickname"]
+
+      if meetween_member?
+        fetch_short_lived_ssh_credentials!(auth.dig("credentials", "token"))
+      end
     end
 
     def meetween_member?
@@ -31,13 +34,23 @@ module Plgrid
       }
     end
 
-    private
-    def fetch_short_lived_ssh_credentials!(token)
-      ccm = Plgrid::Ccm.new(token)
-      ccm.fetch!
-
-      @ssh_key =  ccm.key
-      @ssh_certificate = ccm.certificate
+    def to_user
+      if uid
+        ::User.find_or_initialize_by(uid:).tap do |user|
+          meetween_member? ? user.roles.add(:meetween_member) : user.roles.delete(:meetween_member)
+          user.assign_attributes(attributes)
+          user.save
+        end
+      end
     end
+
+    private
+      def fetch_short_lived_ssh_credentials!(token)
+        ccm = Plgrid::Ccm.new(token)
+        ccm.fetch!
+
+        @ssh_key =  ccm.key
+        @ssh_certificate = ccm.certificate
+      end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   encrypts :ssh_key, :ssh_certificate
   has_many :models, inverse_of: :owner, dependent: :destroy
 
-  roles :admin
+  roles :admin, :meetween_member
 
   def credentials_valid?
     ssh_credentials.valid?

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -5,6 +5,15 @@ class ActiveSupport::TestCase
   include FixtureFactory::Methods
 
   define_factories do
+    factory(:user) do |count|
+      {
+        name: "User#{count}",
+        email: "user#{count}@mltop.local",
+        plgrid_login: "plguser#{count}",
+        uid: "uid-user#{count}"
+      }
+    end
+
     factory(:model) do |count|
       {
         owner: users("marek"),

--- a/test/models/plgrid/user_test.rb
+++ b/test/models/plgrid/user_test.rb
@@ -5,8 +5,10 @@ require "ostruct"
 
 module Plgrid
   class UserTest < ActiveSupport::TestCase
-    test "plgrid login uses auth info to populate user data" do
-      user = User.from_omniauth(auth("plgnewuser", token: CcmHelpers::VALID_TOKEN))
+    test "plgrid login uses auth info and CCM to populate user data for meetween members" do
+      user = User.from_omniauth(auth("plgnewuser",
+        token: CcmHelpers::VALID_TOKEN,
+        groups: [ "plggmeetween", "other", "group" ]))
 
       attrs = {
         name: "plgnewuser Last Name",
@@ -17,17 +19,58 @@ module Plgrid
       }
 
       assert_equal attrs, user.attributes
+      assert user.meetween_member?
+    end
+
+    test "plgrid login uses only auth info to populate user data for not meetween members" do
+      user = User.from_omniauth(auth("plgnewuser",
+        token: CcmHelpers::VALID_TOKEN,
+        groups: [ "other", "group" ]))
+
+      attrs = {
+        name: "plgnewuser Last Name",
+        email: "plgnewuser@b.c",
+        plgrid_login: "plgnewuser",
+        ssh_key: nil,
+        ssh_certificate: nil
+      }
+
+      assert_equal attrs, user.attributes
+      assert_not user.meetween_member?
     end
 
     test "nil proxy when openid connect token is not valid" do
       assert_raise Plgrid::Ccm::FetchError do
-        User.from_omniauth(auth("plgnewuser", token: "invalid"))
+        User.from_omniauth(auth("plgnewuser", token: "invalid", groups: [ "plggmeetween" ]))
       end
     end
 
+    test "meetween users has meetween_member role" do
+      plgrid_user = User.from_omniauth(auth("plgnewuser",
+        token: CcmHelpers::VALID_TOKEN, groups: [ "plggmeetween" ]))
+
+      assert plgrid_user.to_user.meetween_member?
+    end
+
+    test "meetween_member role is removed when user does not belong to plggmeetween group" do
+      user = create(:user, uid: "plgexisting_user", roles: [ :meetween_member ])
+      plgrid_user = User.from_omniauth(auth("plgexisting_user", token: CcmHelpers::VALID_TOKEN, groups: []))
+
+      assert_equal user.id, plgrid_user.to_user.id
+      assert_not plgrid_user.to_user.meetween_member?
+    end
+
+    test "non meetween users does not have meetween_member role" do
+      plgrid_user = User.from_omniauth(auth("plgnewuser",
+        token: CcmHelpers::VALID_TOKEN, groups: [ "plggother" ]))
+
+      assert_not plgrid_user.to_user.meetween_member?
+    end
+
     private
-      def auth(plglogin, token:)
+      def auth(plglogin, token:, groups: [])
         OpenStruct.new(
+          uid: plglogin,
           info: OpenStruct.new(
             nickname: plglogin,
             email: "#{plglogin}@b.c",
@@ -35,6 +78,10 @@ module Plgrid
           ),
           credentials: OpenStruct.new(
             token:
+          ),
+          extra: OpenStruct.new(
+            raw_info: OpenStruct.new(groups:)
+
           )
         )
       end


### PR DESCRIPTION
Meetween research team members are receiving `meetween_member` role. When a user is removed from the group, this role is removed. This is the first step in implementing #114. In the scope of this PR, the following elements will be implemented:
  * [ ] All PLGrid users can log in to mltop, but only Meetween members can start the evaluations.
  * [ ] There will be a new view with a non-Meetween users hypothesis list, where Meetween members can review submissions and start the evaluations.