### PR TITLE
Hack for generating CCM token with lifetime

### DIFF
--- a/app/models/plgrid/ccm.rb
+++ b/app/models/plgrid/ccm.rb
@@ -40,7 +40,12 @@ class Plgrid::Ccm
       Net::HTTP.start(CCM_URI.host, CCM_URI.port,
                       use_ssl: CCM_URI.is_a?(URI::HTTPS),
                       open_timeout: 1, read_timeout: 2) do |http|
-        req = Net::HTTP::Post.new(CCM_URI)
+        # TODO: Remove query param once CCM fixes the issue with not accepting
+        #       lifetime as form data.
+        url = CCM_URI.dup
+        url.query = URI.encode_www_form(lifetime: LIFETIME)
+
+        req = Net::HTTP::Post.new(url)
         req["Authorization"] = "Bearer #{@token}"
         req.set_form_data("lifetime" => LIFETIME)
 

--- a/test/support/ccm_helpers.rb
+++ b/test/support/ccm_helpers.rb
@@ -4,7 +4,7 @@ module CcmHelpers
   VALID_TOKEN = "valid-token"
 
   def self.default_ccm_stubs!
-    ccm = WebMock::RequestPattern.new(:post, "#{Plgrid::Ccm::CCM_URI}")
+    ccm = WebMock::RequestPattern.new(:post, "#{Plgrid::Ccm::CCM_URI}?lifetime=#{Plgrid::Ccm::LIFETIME}")
 
     WebMock.globally_stub_request(:after_local_stubs) do |req|
       if ccm.matches?(req)


### PR DESCRIPTION
CCM does not read lifetime value from the POST form data. This will be fixed in the next CCM release, but until then we need to use query param instead.