### PR TITLE
New evaluation server json schema

### DIFF
--- a/app/controllers/evaluations/scores_controller.rb
+++ b/app/controllers/evaluations/scores_controller.rb
@@ -1,6 +1,10 @@
 class Evaluations::ScoresController < Evaluations::ApplicationController
   def create
-    @evaluation.record_scores!(scores_params)
+    if params[:state] == "OK"
+      @evaluation.record_scores!(scores_params)
+    else
+      @evaluation.record_error!(params[:message])
+    end
 
     head :created
   end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -31,6 +31,10 @@ class Evaluation < ApplicationRecord
     end
   end
 
+  def record_error!(error_message)
+    update! status: :failed, error_message:, token: nil
+  end
+
   def score_for_metric(metric)
     scores.detect { |s| s.metric_id == metric.id } ||
       Score.new(evaluation: self, metric:)

--- a/app/views/submissions/evaluations/_evaluation.html.erb
+++ b/app/views/submissions/evaluations/_evaluation.html.erb
@@ -29,7 +29,12 @@
           </div>
         </div>
         <div class="mt-2">
-          <%= render "submissions/evaluations/scores", evaluation: , metrics: evaluation.evaluator.metrics %>
+          <% if evaluation.failed? %>
+            <div class="text-sm text-red-600"><%= evaluation.error_message %></div>
+          <% else %>
+            <%= render "submissions/evaluations/scores",
+              evaluation: , metrics: evaluation.evaluator.metrics %>
+          <% end %>
         </div>
       </div>
     </li>

--- a/app/views/submissions/evaluations/_scores.html.erb
+++ b/app/views/submissions/evaluations/_scores.html.erb
@@ -1,10 +1,22 @@
 <div class="flex justify-left items-center gap-x-2">
-  <% metrics.each do |metric| %>
-    <span class="text-xs">
-      <%= metric.name%>:
-    </span>
-    <span class="rounded-sm bg-sky-700 px-2 py-1 text-xs font-medium text-white border border-slate-600">
-      <%= evaluation.score_for_metric(metric).value || "-" %>
-    </span>
+  <% if evaluation.failed? %>
+    <% metrics.each do |metric| %>
+      <span class="text-xs">
+        <%= metric.name%>:
+      </span>
+      <span title="<%= evaluation.error_message %>"
+        class="rounded-sm bg-red-700 px-2 py-1 text-xs font-medium text-white border border-red-600">
+        Error
+      </span>
+    <% end %>
+  <% else %>
+    <% metrics.each do |metric| %>
+      <span class="text-xs">
+        <%= metric.name%>:
+      </span>
+      <span class="rounded-sm bg-sky-700 px-2 py-1 text-xs font-medium text-white border border-slate-600">
+        <%= evaluation.score_for_metric(metric).value || "-" %>
+      </span>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/submissions/hypotheses/_hypothesis.html.erb
+++ b/app/views/submissions/hypotheses/_hypothesis.html.erb
@@ -18,9 +18,10 @@
           </div>
           <% if hypothesis.evaluations? %>
             <div class="hidden sm:flex space-x-4">
-                  <% hypothesis.evaluations.each do |evaluation| %>
-                    <%= render "submissions/evaluations/scores", evaluation: , metrics: evaluation.evaluator.metrics %>
-                  <% end %>
+              <% hypothesis.evaluations.each do |evaluation| %>
+                <%= render "submissions/evaluations/scores",
+                  evaluation:, metrics: evaluation.evaluator.metrics %>
+              <% end %>
             </div>
           <% end %>
         </div>

--- a/db/migrate/20250219113521_add_error_message_to_evaluation.rb
+++ b/db/migrate/20250219113521_add_error_message_to_evaluation.rb
@@ -1,0 +1,5 @@
+class AddErrorMessageToEvaluation < ActiveRecord::Migration[8.0]
+  def change
+    add_column :evaluations, :error_message, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_18_093224) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_19_113521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -64,6 +64,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_18_093224) do
     t.string "job_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "error_message"
     t.index ["evaluator_id"], name: "index_evaluations_on_evaluator_id"
     t.index ["hypothesis_id", "evaluator_id"], name: "index_evaluations_on_hypothesis_id_and_evaluator_id", unique: true
     t.index ["hypothesis_id"], name: "index_evaluations_on_hypothesis_id"

--- a/test/integration/evaluations/submit_scores_test.rb
+++ b/test/integration/evaluations/submit_scores_test.rb
@@ -51,6 +51,18 @@ class Evaluations::SubmitScoresTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "record error message when evaluation failed" do
+    token = @evaluation.reset_token!
+
+    post evaluation_scores_path(@evaluation),
+      params: failed_evaluation,
+      headers: headers(token)
+
+    assert_response :success
+    assert_equal "failed", @evaluation.reload.status
+    assert_equal "Evaluation failed", @evaluation.reload.error_message
+  end
+
   test "require valid token" do
     post evaluation_scores_path(@evaluation),
       params: valid_scores,
@@ -66,6 +78,7 @@ class Evaluations::SubmitScoresTest < ActionDispatch::IntegrationTest
       { "Authorization" => authorization, "ContentType" => "application/json" }
     end
 
-    def valid_scores   = { scores: { blue: 1, chrf: 2, ter: 3.3 } }
-    def invalid_scores = { scores: { blue: 1, chrf: 2 } }
+    def valid_scores   = { state: "OK", scores: { blue: 1, chrf: 2, ter: 3.3 } }
+    def invalid_scores = { state: "OK", scores: { blue: 1, chrf: 2 } }
+    def failed_evaluation = { state: "ERROR", message: "Evaluation failed" }
 end


### PR DESCRIPTION
Use the new evaluation server JSON format and report the error

The schema was changed to:
    
```json
{ "state": "OK", "scores": {"bleu": 31.35, "chrf": 58.50, "ter": 57.83} }
{ "state": "ERROR", "reason": "bla bla bla", "scores": {"bleu": "UNKOWN", "chrf": "UNKOWN", "ter": "UNKNOWN"} }
```
    
As a result, we have information when there are any errors connected with evaluation.
