### PR TITLE
add source and target language filter to task leaderboard

### DIFF
--- a/app/controllers/tasks/leaderboards_controller.rb
+++ b/app/controllers/tasks/leaderboards_controller.rb
@@ -12,10 +12,15 @@ class Tasks::LeaderboardsController < ApplicationController
     @task = Task.with_published_test_sets.includes(:metrics).find(params[:task_id])
     if Mltop.ranking_released?
       @rows = Top::Row
-        .where(task: @task)
-        .order(test_set: selected_test_set, metric: selected_metric, order: selected_order)
+        .where(task: @task,
+          source: params[:source],
+          target: params[:target])
+        .order(test_set: selected_test_set,
+          metric: selected_metric,
+          order: selected_order
+          )
     else
-      @rows = []
+      @rows = Top::Row.none
     end
   end
 

--- a/app/models/top/row.rb
+++ b/app/models/top/row.rb
@@ -15,19 +15,35 @@ class Top::Row
     @cached_scores = {}
   end
 
-  def self.where(task:, test_set: nil)
+  def self.where(task:, test_set: nil, source: nil, target: nil)
     scores = Score
       .joins([ :metric, evaluation: { hypothesis: :test_set_entry } ])
       .where(evaluation: { hypotheses: { test_set_entries: { task_id: task } } })
     scores = scores.where(evaluation: { hypotheses: { test_set_entries: { test_set_id: test_set } } }) if test_set
+    scores = scores.where(evaluation: { hypotheses: { test_set_entries: { source_language: source } } }) unless source.blank?
+    scores = scores.where(evaluation: { hypotheses: { test_set_entries: { target_language: target } } }) unless target.blank?
 
     scores = scores.select("scores.value, scores.metric_id, hypotheses.model_id, test_set_entries.test_set_id, test_set_entries.id as test_set_entry_id, metrics.worst_score as metric_worst_score")
-    entries_counts = task.test_set_entries.group("test_set_id").count
+    entries = task.test_set_entries
+    entries = entries.where(source_language: source) unless source.blank?
+    entries = entries.where(target_language: target) unless target.blank?
+    entries_counts = entries.group("test_set_id").count
     scores_by_model_id = scores.group_by { |score| score.model_id }
     models = Model.where(id: scores_by_model_id.keys).index_by(&:id)
     rows = scores_by_model_id.map { |model_id, scores| new(models[model_id], scores, entries_counts) }
 
-    Top::Rows.new(rows)
+    entries = task.test_set_entries
+    entries = entries.where(test_set:) if test_set
+
+    source_languages, target_languages = entries
+      .pluck(:source_language, :target_language)
+      .transpose.map(&:uniq)
+
+    Top::Rows.new(rows, source_languages, target_languages, source, target)
+  end
+
+  def self.none
+    Top::Rows.new([], [], [], nil, nil)
   end
 
   def score(test_set:, metric:, test_set_entry: nil)

--- a/app/models/top/rows.rb
+++ b/app/models/top/rows.rb
@@ -1,8 +1,13 @@
 class Top::Rows
   delegate_missing_to :@rows
+  attr_reader :source_languages, :target_languages
 
-  def initialize(rows)
+  def initialize(rows, source_languages, target_languages, source, target)
     @rows = rows
+    @source_languages = source_languages
+    @target_languages = target_languages
+    @source = source
+    @target = target
   end
 
   def order(test_set:, metric:, order: "desc", test_set_entry: nil)
@@ -22,9 +27,14 @@ class Top::Rows
         end
       end
 
-      Top::Rows.new(rows)
+      Top::Rows.new(rows, source_languages, target_languages, @source, @target)
     else
       self
     end
+  end
+
+  def average?
+    (@source.blank? && source_languages.size > 1) ||
+      (@target.blank? && target_languages.size > 1)
   end
 end

--- a/app/views/tasks/leaderboards/_filters.html.erb
+++ b/app/views/tasks/leaderboards/_filters.html.erb
@@ -1,0 +1,25 @@
+<% if rows.source_languages.present? || rows.target_languages.present? %>
+  <div class="mx-16 mt-5 mb-5">
+    <%= form_tag task_leaderboard_path(@task), method: :get, class: "flex place-content-center", data: { controller: "auto-submit" } do %>
+      <div class="mr-4">
+        <label for="source" class="block text-sm font-medium text-gray-700">Source language</label>
+        <%= select_tag "source", options_for_select([["", nil]] + rows.source_languages, params[:source]),
+            id: "source",
+            class: "mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6",
+            data: { action: "change->auto-submit#submit" } %>
+      </div>
+
+      <div>
+        <label for="target" class="block text-sm font-medium text-gray-700">Target language</label>
+        <%= select_tag "target", options_for_select([["", nil]] + rows.target_languages, params[:target]),
+            id: "target",
+            class: "mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6",
+            data: { action: "change->auto-submit#submit" } %>
+      </div>
+
+      <div class="ml-2 flex justify-center mt-4 pt-4">
+        <%= link_to "Reset", task_leaderboard_path(@task), class: "btn btn-secondary text-sm py-1 px-2" %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/tasks/leaderboards/_leaderboard.html.erb
+++ b/app/views/tasks/leaderboards/_leaderboard.html.erb
@@ -7,6 +7,11 @@
       <% task.test_sets.each do |test_set| %>
         <th colspan="<%= task.metrics.size %>" class="border border-zinc-300 dark:border-zinc-600 font-semibold p-4 text-zinc-900 dark:text-zinc-200 text-center">
           <%= link_to test_set.name, test_set_leaderboard_path(test_set) %>
+            <% if rows.average? %>
+             <span class="text-gray-400 cursor-pointer" title="Presented score is an average for all matching languages. If both source and target languages are specified, the score reflects a specific value.">
+                <%= info_icon("h-4 w-4 inline") %>
+              </span>
+            <% end %>
         </th>
         <% end %>
     </tr>

--- a/app/views/tasks/leaderboards/show.html.erb
+++ b/app/views/tasks/leaderboards/show.html.erb
@@ -8,6 +8,8 @@
 
 <%= render "tasks/menu", task: @task %>
 
+<%= render "filters", rows: @rows %>
+
 <% if @rows.size.positive? %>
   <%= render "leaderboard", task: @task, rows: @rows %>
 <% else %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 require "freezolite/auto"
 
 module Mltop
-  LANGUAGES = %w[be bg bs ca cs da de el en en es et fi fr ga gl hr hu is it lb lt lv mk mt nl no pl pr pt ro ru sk sl sr sv th tr uk ar zh]
+  LANGUAGES = %w[be bg bs ca cs da de el en es et fi fr ga gl hr hu is it lb lt lv mk mt nl no pl pr pt ro ru sk sl sr sv th tr uk ar zh]
 
   def self.hpc_client(user, host)
     Rails.configuration.hpc_client.constantize.for(user, host)

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -8,6 +8,16 @@ flores_st_en_pl_groundtruth:
   record: flores_st_en_pl (TestSetEntry)
   blob: flores_st_en_pl_groundtruth_blob
 
+flores_st_en_de_input:
+  name: input
+  record: flores_st_en_de (TestSetEntry)
+  blob: flores_st_en_de_input_blob
+
+flores_st_en_de_groundtruth:
+  name: groundtruth
+  record: flores_st_en_de (TestSetEntry)
+  blob: flores_st_en_de_groundtruth_blob
+
 
 flores_st_en_it_input:
   name: input

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -1,6 +1,9 @@
 flores_st_en_pl_input_blob: <%= ActiveStorage::FixtureSet.blob filename: "input.txt" %>
 flores_st_en_pl_groundtruth_blob: <%= ActiveStorage::FixtureSet.blob filename: "input.txt" %>
 
+flores_st_en_de_input_blob: <%= ActiveStorage::FixtureSet.blob filename: "input.txt" %>
+flores_st_en_de_groundtruth_blob: <%= ActiveStorage::FixtureSet.blob filename: "input.txt" %>
+
 flores_st_en_it_input_blob: <%= ActiveStorage::FixtureSet.blob filename: "input.txt" %>
 flores_st_en_it_groundtruth_blob: <%= ActiveStorage::FixtureSet.blob filename: "input.txt" %>
 

--- a/test/fixtures/test_set_entries.yml
+++ b/test/fixtures/test_set_entries.yml
@@ -4,6 +4,12 @@ flores_st_en_pl:
   source_language: en
   target_language: pl
 
+flores_st_en_de:
+  task: st
+  test_set: flores
+  source_language: en
+  target_language: de
+
 flores_st_en_it:
   task: st
   test_set: flores
@@ -33,7 +39,7 @@ mustc_st_en_pl:
   task: st
   test_set: mustc
   source_language: en
-  target_language: pl 
+  target_language: pl
 
 mustc_st_pl_en:
   task: st

--- a/test/models/test_set_test.rb
+++ b/test/models/test_set_test.rb
@@ -6,14 +6,14 @@ class TestSetTest < ActiveSupport::TestCase
     task = tasks("st")
 
     assert_equal [ "en", "pl" ].sort, test_set.source_languages_for(task:).sort
-    assert_equal [ "en", "pl", "it" ].sort, test_set.target_languages_for(task:).sort
+    assert_equal [ "de", "en", "pl", "it" ].sort, test_set.target_languages_for(task:).sort
   end
 
   test "get test set entry by language" do
     test_set = test_sets("flores")
     task = tasks("st")
 
-    assert_nil test_set.entry_language_for(source: "en", target: "de", task:), "Should return nil on non existing subtask test set"
+    assert_nil test_set.entry_language_for(source: "en", target: "fr", task:), "Should return nil on non existing subtask test set"
     assert_equal test_set_entries("flores_st_en_pl"), test_set.entry_language_for(source: "en", target: "pl", task:)
     assert_equal test_set_entries("flores_st_pl_en"), test_set.entry_language_for(source: "pl", target: "en", task:)
   end
@@ -24,8 +24,8 @@ class TestSetTest < ActiveSupport::TestCase
 
     entries = flores.entries.for_task(st)
 
-    assert_equal 3, entries.size
-    assert_equal test_set_entries("flores_st_en_pl", "flores_st_en_it", "flores_st_pl_en"), entries
+    assert_equal 4, entries.size
+    assert_equal test_set_entries("flores_st_en_pl", "flores_st_en_de", "flores_st_en_it", "flores_st_pl_en"), entries
   end
 
   test "get all published test sets" do


### PR DESCRIPTION
In task leaderboard, when there are multiple entries for a test set, we avg the whole score and users have no way to see the exact score there. To solve it, filters by source and target language are added.
- Enables filtering by source and target language
- Adding a filter also limits the entries we compare against when calculating an avg eg choosing `en` as source will calculate of all en scores / number of en entries
- Info icon to indicate that we may calculate an avg has been added next to test set name