### PR TITLE
Add worst and best scores to metric

### DIFF
--- a/app/controllers/admin/evaluators/metrics_controller.rb
+++ b/app/controllers/admin/evaluators/metrics_controller.rb
@@ -49,7 +49,7 @@ module Admin
         end
 
         def metric_params
-          params.require(:metric).permit(:name)
+          params.require(:metric).permit(:name, :order, :worst_score, :best_score)
         end
     end
   end

--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -209,4 +209,13 @@ module IconsHelper
     SVG
     .html_safe
   end
+
+  def info_icon(css_classes = "")
+    <<~SVG
+      <svg class="#{css_classes}" width="17" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z" />
+      </svg>
+    SVG
+    .html_safe
+  end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -17,26 +17,29 @@ module TasksHelper
     end
 
   def interpolate_color(metric_value, metric)
-      value = metric_value ? [ 0, [ 100, metric_value ].min ].max : 0
-      value = 100 - value if metric.asc?
-      red = [ 255, 0, 0 ]
-      yellow = [ 255, 255, 0 ]
-      green = [ 0, 255, 0 ]
+    worst = metric.worst_score
+    best = metric.best_score
+    value = metric_value || worst
 
-      # Interpolate between red and yellow
-      if value <= 50
-          ratio = value / 50.0
-          r = (red[0] + ratio * (yellow[0] - red[0])).to_i
-          g = (red[1] + ratio * (yellow[1] - red[1])).to_i
-          b = (red[2] + ratio * (yellow[2] - red[2])).to_i
-      # Interpolate between yellow and green
-      else
-          ratio = (value - 50) / 50.0
-          r = (yellow[0] + ratio * (green[0] - yellow[0])).to_i
-          g = (yellow[1] + ratio * (green[1] - yellow[1])).to_i
-          b = (yellow[2] + ratio * (green[2] - yellow[2])).to_i
-      end
+    normalized = (value - worst) / (best - worst)
+    normalized = 1.0 - normalized if metric.asc?
 
-      "rgb(#{r}, #{g}, #{b})"
+    red    = [ 255, 0, 0 ]
+    yellow = [ 255, 255, 0 ]
+    green  = [ 0, 255, 0 ]
+
+    if normalized <= 0.5
+      ratio = normalized / 0.5
+      r = (red[0] + ratio * (yellow[0] - red[0])).to_i
+      g = (red[1] + ratio * (yellow[1] - red[1])).to_i
+      b = (red[2] + ratio * (yellow[2] - red[2])).to_i
+    else
+      ratio = (normalized - 0.5) / 0.5
+      r = (yellow[0] + ratio * (green[0] - yellow[0])).to_i
+      g = (yellow[1] + ratio * (green[1] - yellow[1])).to_i
+      b = (yellow[2] + ratio * (green[2] - yellow[2])).to_i
+    end
+
+    "rgb(#{r}, #{g}, #{b})"
   end
 end

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -2,10 +2,21 @@ class Metric < ApplicationRecord
   belongs_to :evaluator
   has_many :scores, dependent: :destroy
 
-  validates :name, presence: true
+  validates :name, :best_score, :worst_score, presence: true
+  validate :proper_score_range
 
   enum :order, {
     asc: 0,
     desc: 1
   }
+
+  private
+  def proper_score_range
+    if asc? && best_score >= worst_score
+      errors.add(:best_score, "Best score has to be lesser than worst score")
+    end
+    if desc? && best_score <= worst_score
+      errors.add(:best_score, "Best score has to be greater than worst score")
+    end
+  end
 end

--- a/app/views/admin/evaluators/metrics/_form.html.erb
+++ b/app/views/admin/evaluators/metrics/_form.html.erb
@@ -5,6 +5,9 @@
   <div class="space-y-12">
     <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
       <%= form.text_field :name, wrapper: "sm:col-span-4" %>
+      <%= form.select :order, Metric.orders.keys, wrapper: "sm:col-span-4" %>
+      <%= form.number_field :worst_score, wrapper: "sm:col-span-4" %>
+      <%= form.number_field :best_score, wrapper: "sm:col-span-4" %>
     </div>
   </div>
 

--- a/app/views/tasks/leaderboards/_leaderboard.html.erb
+++ b/app/views/tasks/leaderboards/_leaderboard.html.erb
@@ -15,7 +15,10 @@
         <% task.metrics.each do |metric| %>
           <th class="border border-zinc-300 dark:border-zinc-600 font-semibold p-4 text-zinc-900 dark:text-zinc-200 text-center">
             <%= link_to task_leaderboard_path(task, mid: metric.id, tsid: test_set.id, o: metric_order(test_set, metric)), class: "flex items-center justify-center" do %>
-              <span class="mr-3"><%= metric.name %></span>
+              <span class="cursor-pointer mr-1" title="<%="Score range: #{metric.worst_score} - #{metric.best_score}"%>">
+                <%= info_icon("text-gray-400 h-4 w-4 inline mr-1") %>
+                <span><%= metric.name %></span>
+              </span>
               <%= sort_chevron(test_set, metric) %>
             <% end %>
           </th>

--- a/app/views/test_sets/leaderboards/_leaderboard.html.erb
+++ b/app/views/test_sets/leaderboards/_leaderboard.html.erb
@@ -7,7 +7,10 @@
       <% task.metrics.each do |metric| %>
         <th rowspan="2" class="leaderboard-item">
           <%= link_to test_set_leaderboard_path(test_set, tid: task.id, mid: metric.id, o: aggregated_metric_order(metric)), class: "flex items-center justify-center" do %>
-            <span class="mr-3"><%= metric.name %></span>
+            <span class="flex items-center cursor-pointer mr-1" title="<%="Score range: #{metric.worst_score} - #{metric.best_score}"%>">
+                <%= info_icon("text-gray-400 h-4 w-4 inline mr-1") %>
+                <%= metric.name %>
+              </span>
             <%= aggregated_metric_sort_chevron(metric) %>
           <% end %>
         </th>
@@ -23,7 +26,10 @@
         <% task.metrics.each do |metric| %>
           <th class="leaderboard-item">
             <%= link_to test_set_leaderboard_path(test_set, tid: task.id, mid: metric.id, sid: test_set_entry.id, o: test_set_metric_order(test_set_entry, metric)), class: "flex items-center justify-center" do %>
-              <span class="mr-3"><%= metric.name %></span>
+              <span class="flex items-center cursor-pointer mr-1" title="<%="Score range: #{metric.worst_score} - #{metric.best_score}"%>">
+                <%= info_icon("text-gray-400 h-4 w-4 inline mr-1") %>
+                <%= metric.name %>
+              </span>
               <%= test_set_sort_chevron(test_set_entry, metric) %>
             <% end %>
           </th>

--- a/db/data/evaluators.yml
+++ b/db/data/evaluators.yml
@@ -28,10 +28,16 @@ screbleu:
   metrics:
     - name: bleu
       order: desc
+      worst_score: 0
+      best_score: 100
     - name: chrf
       order: desc
+      worst_score: 0
+      best_score: 100
     - name: ter
       order: asc
+      worst_score: 100
+      best_score: 0
   tasks:
     - MT
     - ST
@@ -72,6 +78,8 @@ blueurt:
   metrics:
     - name: bleurt
       order: asc
+      worst_score: 1
+      best_score: 0
   tasks:
     - MT
     - ST
@@ -110,6 +118,8 @@ wer:
   metrics:
     - name: wer
       order: asc
+      worst_score: 1
+      best_score: 0
   tasks:
   #  - MT # not sure if it should be here - check Gdrive table
   #  - ST
@@ -156,6 +166,8 @@ rogue:
   metrics:
     - name: rouge
       order: desc
+      worst_score: 0
+      best_score: 100
   tasks:
     - SUM
     - SSUM
@@ -196,6 +208,8 @@ accuracy:
   metrics:
     - name: accuracy
       order: desc
+      worst_score: 0
+      best_score: 1
   tasks:
     - SQA
   input_modality:
@@ -234,6 +248,8 @@ exact-match:
   metrics:
     - name: exact-match
       order: desc
+      worst_score: 0
+      best_score: 1
   tasks:
     - SQA
   input_modality:
@@ -272,6 +288,8 @@ f1-score:
   metrics:
     - name: f1-score
       order: desc
+      worst_score: 0
+      best_score: 1
   tasks:
     - SQA
   input_modality:
@@ -313,6 +331,8 @@ comet:
   metrics:
     - name: comet
       order: desc
+      worst_score: 0
+      best_score: 1
   tasks:
     - MT
     - ST
@@ -353,7 +373,9 @@ characTER:
   host: ares.cyfronet.pl
   metrics:
     - name: characTER
-      order: desc
+      order: asc
+      worst_score: 1
+      best_score: 0
   tasks:
     - ST
     - MT
@@ -395,8 +417,12 @@ slu:
   metrics:
     - name: slot_type_f1
       order: desc
+      worst_score: 0
+      best_score: 1
     - name: slot_value_cer
-      order: desc
+      order: asc
+      worst_score: 1
+      best_score: 0
     # "intent_accuracy": {
     #     "mean": 0.7841291190316073,
     #     "standard_error": 0.007544324162844738
@@ -440,8 +466,12 @@ sqa-hf:
   metrics:
     - name: exact_match
       order: desc
+      worst_score: 0
+      best_score: 100
     - name: f1
       order: desc
+      worst_score: 0
+      best_score: 1
   tasks:
     - SQA
 

--- a/db/iwslt/evaluators.yml
+++ b/db/iwslt/evaluators.yml
@@ -31,12 +31,20 @@ if:
   metrics:
     - name: SQA-BERTScore
       order: desc
+      worst_score: -1
+      best_score: 1
     - name: SSUM-BERTScore
       order: desc
+      worst_score: 0
+      best_score: 1
     - name: ASR-WER
       order: asc
+      worst_score: 1
+      best_score: 0
     - name: ST-COMET
-      order: asc
+      order: desc
+      worst_score: -1
+      best_score: 1
   tasks:
     - IFLONG
     - IFSHORT
@@ -75,7 +83,9 @@ comet:
   host: athena.cyfronet.pl
   metrics:
     - name: comet
-      order: asc
+      order: desc
+      worst_score: 0
+      best_score: 1
   tasks:
     - OFFLINE
     - MODELCOMPRESSION
@@ -113,10 +123,16 @@ screbleu:
   metrics:
     - name: bleu
       order: desc
+      worst_score: 0
+      best_score: 100
     - name: chrf
       order: desc
+      worst_score: 0
+      best_score: 100
     - name: ter
       order: asc
+      worst_score: 100
+      best_score: 0
   tasks:
     - OFFLINE
   to: text
@@ -154,6 +170,8 @@ bleurt:
   metrics:
     - name: bleurt
       order: asc
+      worst_score: 1
+      best_score: 0
   tasks:
     - OFFLINE
   to: text
@@ -191,6 +209,8 @@ characTER:
   metrics:
     - name: characTER
       order: asc
+      worst_score: 1
+      best_score: 0
   tasks:
     - OFFLINE
   to: text

--- a/db/migrate/20250430121929_add_best_and_worst_score_to_metric.rb
+++ b/db/migrate/20250430121929_add_best_and_worst_score_to_metric.rb
@@ -1,0 +1,9 @@
+class AddBestAndWorstScoreToMetric < ActiveRecord::Migration[8.0]
+  def change
+    add_column :metrics, :best_score, :float, null: false, default: 0
+    add_column :metrics, :worst_score, :float, null: false, default: 100
+
+    change_column_default :metrics, :best_score, from: 0, to: nil
+    change_column_default :metrics, :worst_score, from: 100, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_29_093424) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_30_121929) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -97,7 +97,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_093424) do
     t.bigint "evaluator_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "order", default: 0, null: false
+    t.integer "order", default: 1, null: false
+    t.float "best_score", null: false
+    t.float "worst_score", null: false
     t.index ["evaluator_id"], name: "index_metrics_on_evaluator_id"
   end
 

--- a/lib/tasks_loader.rb
+++ b/lib/tasks_loader.rb
@@ -26,7 +26,7 @@ class TasksLoader
       data["tasks"].each { |slug| evaluator.task_evaluators.find_or_create_by(task: tasks[slug]) }
       data["metrics"].each do |hsh|
         metric = evaluator.metrics.find_or_initialize_by(name: hsh["name"])
-        metric.update!(order: hsh["order"])
+        metric.update!(order: hsh["order"], worst_score: hsh["worst_score"], best_score: hsh["best_score"])
       end
     end
   end

--- a/test/controllers/admin/evaluations/metrics_controller_test.rb
+++ b/test/controllers/admin/evaluations/metrics_controller_test.rb
@@ -14,7 +14,10 @@ class Admin::Evaluators::MetricsControllerTest < ActionDispatch::IntegrationTest
     evaluator = evaluators("sacrebleu")
     assert_difference("evaluator.metrics.count") do
       post admin_evaluator_metrics_path(evaluator, format: :turbo_stream), params: { metric: {
-        name: "new-metric"
+        name: "new-metric",
+        order: "desc",
+        worst_score: 20,
+        best_score: 120
       } }
     end
 

--- a/test/fixtures/metrics.yml
+++ b/test/fixtures/metrics.yml
@@ -2,18 +2,27 @@ blue:
   name: blue
   order: desc
   evaluator: sacrebleu
+  worst_score: 0
+  best_score: 100
 
 chrf:
   name: chrf
   order: desc
   evaluator: sacrebleu
+  worst_score: 0
+  best_score: 100
+  best_score: 100
 
 ter:
   name: ter
   order: asc
   evaluator: sacrebleu
+  worst_score: 100
+  best_score: 0
 
 blueurt:
   name: blueurt
   order: desc
   evaluator: blueurt
+  worst_score: 0
+  best_score: 1


### PR DESCRIPTION
Metrics can have different ranges, it's not always 0-100 or 100-0. It can even differ for the same metric between challenges, depending if it's normalized. This task adds `worst_score` and `best_score` to `metric`. If score doesn't have a value, `metric.worst_score` is taken. These values are also used to properly interpolate color in leaderboards

todo: db has default descending order on metrics, but the default value rails give is ascending, because it's the 0 value of the enum - I've added default values for best and worst score according to `asc` value, so default db value should be adjusted