### PR TITLE
singular ssh connection in run job

### DIFF
--- a/app/jobs/evaluations/run_job.rb
+++ b/app/jobs/evaluations/run_job.rb
@@ -1,7 +1,16 @@
 module Evaluations
   class RunJob < ApplicationJob
     def perform(evaluations:, user:)
-      evaluations.map { |evaluation| evaluation.run(user) }
+      evaluations.group_by { |evaluation| evaluation.evaluator.host }.map do |host, evaluations|
+        backend = HPCKit::Slurm::Backends::Netssh.new(
+          host, user.plgrid_login,
+          key_data: [ user.ssh_key ], keycert_data: [ user.ssh_certificate ], keys_only: true
+        )
+        connection = HPCKit::Slurm::Restd.new(backend)
+        connection.start do |restd_runner|
+          evaluations.map { |evaluation| evaluation.run(user, restd_runner) }
+        end
+      end
     end
   end
 end

--- a/app/models/hpc/client.rb
+++ b/app/models/hpc/client.rb
@@ -1,10 +1,12 @@
   class Hpc::Client
-    def self.for(user, host)
-      backend = HPCKit::Slurm::Backends::Netssh.new(
-        host, user.plgrid_login,
-        key_data: [ user.ssh_key ], keycert_data: [ user.ssh_certificate ], keys_only: true
-      )
-      connection = HPCKit::Slurm::Restd.new(backend)
+    def self.for(user, host, connection = nil)
+      connection ||= begin
+        backend = HPCKit::Slurm::Backends::Netssh.new(
+          host, user.plgrid_login,
+          key_data: [ user.ssh_key ], keycert_data: [ user.ssh_certificate ], keys_only: true
+        )
+        HPCKit::Slurm::Restd.new(backend)
+      end
       HPCKit::Slurm::Client.new(connection)
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,8 +11,8 @@ require "freezolite/auto"
 module Mltop
   LANGUAGES = %w[be bg bs ca cs da de el en es et fi fr ga gl hr hu is it lb lt lv mk mt nl no pl pr pt ro ru sk sl sr sv th tr uk ar zh]
 
-  def self.hpc_client(user, host)
-    Rails.configuration.hpc_client.constantize.for(user, host)
+  def self.hpc_client(user, host, restd_runner = nil)
+    Rails.configuration.hpc_client.constantize.for(user, host, restd_runner)
   end
 
   def self.ranking_released?

--- a/test/jobs/evaluations/run_job_test.rb
+++ b/test/jobs/evaluations/run_job_test.rb
@@ -3,14 +3,26 @@ require "test_helper"
 module Evaluations
   class RunJobTest < ActiveJob::TestCase
     def setup
-      @evaluation = Minitest::Mock.new
+      @evaluation = create(:evaluation)
       @user = users("marek")
     end
 
     test "submits evaluations" do
-      @evaluation.expect(:run, true, [ @user ])
+      stub_ssh_connection
+      Evaluation.any_instance.stubs(:run).returns(true)
       RunJob.perform_now(evaluations: [ @evaluation ], user: @user)
-      assert @evaluation.verify
+    end
+
+    private
+
+    def stub_ssh_connection
+      HPCKit::Slurm::Backends::Netssh.stubs(:new)
+      @restd = Minitest::Mock.new
+      @restd_runner = Minitest::Mock.new
+      HPCKit::Slurm::Restd.stubs(:new).returns(@restd)
+      @restd.expect(:start, nil) do |&block|
+        block.call(@restd_runner)
+      end
     end
   end
 end

--- a/test/support/hpc/client_mock.rb
+++ b/test/support/hpc/client_mock.rb
@@ -1,5 +1,5 @@
 class Hpc::ClientMock
-  def self.for(user, host)
+  def self.for(user, host, restd_runner = nil)
     new()
   end
 


### PR DESCRIPTION
Run job is performed within a singular ssh connection - one per host.
Restd and it's runner share the same interface. That means we can swap what we pass to Client, starting the connection earlier, and without changing a thing in hpckit, we will be able to run all evaluations using single connection. 

To achieve it, `Evaluation.run` and methods initialising client need to accept additional parameter