### PR TITLE
assign tasks and test sests to challenge in dev recreate

### DIFF
--- a/lib/tasks/test_sets.rake
+++ b/lib/tasks/test_sets.rake
@@ -1,8 +1,8 @@
 namespace :test_sets do
-  task :synchronize, [ :user_login ] => [ :environment ] do |t, args|
+  task :synchronize, [ :user_login, :challenge_id ] => [ :environment ] do |t, args|
     require "test_sets_loader"
 
-    loader = TestSetsLoader.new(username: args.fetch(:user_login))
+    loader = TestSetsLoader.new(username: args.fetch(:user_login), challenge_id: args.fetch(:challenge_id))
 
     loader.synchronize_with_remote!
 

--- a/lib/test_sets_loader.rb
+++ b/lib/test_sets_loader.rb
@@ -3,8 +3,9 @@ class TestSetsLoader
   TASKS_DIR = File.join(Rails.root, "tmp/tasks")
   REMOTE_TASKS_DIR = "/net/pr2/projects/plgrid/plggmeetween/tasks"
 
-  def initialize(username:, hostname: HOSTNAME, remote_tasks_dir: REMOTE_TASKS_DIR, tasks_dir: TASKS_DIR)
+  def initialize(username:, challenge_id:, hostname: HOSTNAME, remote_tasks_dir: REMOTE_TASKS_DIR, tasks_dir: TASKS_DIR)
     @username = username
+    @challenge_id = challenge_id
     @hostname = hostname
     @remote_tasks_dir = remote_tasks_dir
     @tasks_dir = tasks_dir
@@ -14,7 +15,7 @@ class TestSetsLoader
     note "Importing tasks started"
     Task.transaction do
       Pathname.new(@tasks_dir).children.select(&:directory?).each do |dir|
-        loader = TestSetLoader::Processor.for(dir)
+        loader = TestSetLoader::Processor.for(dir, @challenge_id)
         note "Importing #{dir.basename} using #{loader.class}"
 
         loader.import!


### PR DESCRIPTION
closes #202 
TestSetProcessor was faulty (maybe some issues when mergin iwslt changes)
adds a challenge to both loaders so we can properly assign tasks, test sets and evaluators