### PR TITLE
update memberships during login

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -50,6 +50,10 @@ class Challenge < ApplicationRecord
     roles_manager.update_memberships
   end
 
+  def update_membership(membership)
+    roles_manager.update_membership(membership)
+  end
+
   private
     def roles_manager = Challenge::RolesManager.new(self)
 end

--- a/app/models/challenge/roles_manager.rb
+++ b/app/models/challenge/roles_manager.rb
@@ -11,6 +11,10 @@ class Challenge::RolesManager
     end
   end
 
+  def update_membership(membership)
+    update_membership_status(membership)
+  end
+
   def role_for(user)
     owner?(user) || manager_role?(user) ? :manager : :participant
   end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -8,6 +8,11 @@ class Membership < ApplicationRecord
   validate :satisfies_access_rules
   roles AccessRule.valid_roles
 
+
+  def update_role
+    challenge.update_membership(self)
+  end
+
   private
     def satisfies_access_rules
       errors.add(:user, "Only #{challenge.access_rules.map(&:group_name).join(",")} group members can join this challenge") unless satisfies_access_rules?

--- a/app/models/sso/plgrid.rb
+++ b/app/models/sso/plgrid.rb
@@ -24,6 +24,7 @@ module Sso
           meetween_member? ? user.roles.add(:meetween_member) : user.roles.delete(:meetween_member)
           user.assign_attributes(attributes)
           user.save
+          update_memberships(user) if user.groups_previously_changed?
         end
       end
     end
@@ -50,6 +51,10 @@ module Sso
 
         @ssh_key =  ccm.key
         @ssh_certificate = ccm.certificate
+      end
+
+      def update_memberships(user)
+        user.memberships.map(&:update_role)
       end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_many :models, inverse_of: :owner, dependent: :destroy
   has_many :evaluations, class_name: "Evaluation", foreign_key: "creator_id"
   has_many :challenges, inverse_of: :owner, dependent: :destroy
+  has_many :memberships, dependent: :destroy
 
   roles :admin, :meetween_member
 

--- a/test/models/challenge/roles_manager_test.rb
+++ b/test/models/challenge/roles_manager_test.rb
@@ -19,13 +19,13 @@ class Challenge::RolesManagerTest < ActiveSupport::TestCase
 
   test "name changes, but user still has access from other group - membership should stay as is" do
     @user.update(groups: [ "old name", "other group" ])
-    create(:access_rule, challenge: @challenge, group_name: "other group", roles: [ :participant ])
+    create(:access_rule, challenge: @challenge, group_name: "other group", roles: [ :manager ])
     @access_rule.update(group_name: "new name")
 
     assert_no_changes "Membership.count" do
       @challenge.update_memberships
     end
-    assert @membership.manager?
+    assert @membership.reload.manager?
   end
 
   test "role is changed to participant - membership is downgraded to participant" do
@@ -43,7 +43,6 @@ class Challenge::RolesManagerTest < ActiveSupport::TestCase
 
     @challenge.update_memberships
 
-    @membership.reload
     assert @membership.reload.has_role?(:manager)
   end
 
@@ -55,5 +54,52 @@ class Challenge::RolesManagerTest < ActiveSupport::TestCase
     @challenge.update_memberships
 
     assert @membership.reload.manager?
+  end
+
+   test "#update_membership membership should be deleted when it was only one granting user access" do
+    @access_rule.update(group_name: "new name")
+
+    assert_changes "Membership.count", -1 do
+      @challenge.update_membership(@membership)
+    end
+  end
+
+  test "#update_membership name changes, but user still has access from other group - membership should stay as is" do
+    @user.update(groups: [ "old name", "other group" ])
+    create(:access_rule, challenge: @challenge, group_name: "other group", roles: [ :manager ])
+    @access_rule.update(group_name: "new name")
+
+    assert_no_changes "Membership.count" do
+      @challenge.update_membership(@membership)
+    end
+    assert @membership.manager?
+  end
+
+  test "#update_membership role is changed to participant - membership is downgraded to participant" do
+    @access_rule.update(roles: [ :manager ])
+
+    @challenge.update_membership(@membership)
+
+    assert @membership.manager?
+  end
+
+
+  test "#update_membership other group created with participant, membership stays as is" do
+    @user.update(groups: [ "old name", "other group" ])
+    create(:access_rule, challenge: @challenge, group_name: "other group", roles: [ :participant ])
+
+    @challenge.update_membership(@membership)
+
+    assert @membership.has_role?(:manager)
+  end
+
+  test "#update_membership role is changed to manager, but membership stays as is because of other group" do
+    @user.update(groups: [ "old name", "other group" ])
+    create(:access_rule, challenge: @challenge, group_name: "other group", roles: [ :manager ])
+
+    @access_rule.update(roles: [ :participant ])
+    @challenge.update_membership(@membership)
+
+    assert @membership.manager?
   end
 end


### PR DESCRIPTION
If user groups change between logins, we have to update the memberships