### PR TITLE
Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 # Omakase Ruby styling for Rails
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
+Layout/IndentationConsistency:
+  Enabled: true
+Layout/IndentationWidth:
+  Enabled: true
 # Overwrite or add rules to create your own house style
 #
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,8 @@ Layout/IndentationConsistency:
   Enabled: true
 Layout/IndentationWidth:
   Enabled: true
+Layout/EmptyLines:
+  Enabled: true
 # Overwrite or add rules to create your own house style
 #
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`

--- a/app/controllers/challenges/dashboard/access_rules_controller.rb
+++ b/app/controllers/challenges/dashboard/access_rules_controller.rb
@@ -42,10 +42,10 @@ module Challenges
 
       private
 
-      def set_and_authorize_access_rule
-        @access_rule = AccessRule.find(params[:id])
-        authorize(@access_rule)
-      end
+        def set_and_authorize_access_rule
+          @access_rule = AccessRule.find(params[:id])
+          authorize(@access_rule)
+        end
     end
   end
 end

--- a/app/controllers/challenges/dashboard/consents_controller.rb
+++ b/app/controllers/challenges/dashboard/consents_controller.rb
@@ -46,10 +46,10 @@ module Challenges
 
       private
 
-      def set_and_authorize_consent
-        @consent = Consent.find(params[:id])
-        authorize(@consent)
-      end
+        def set_and_authorize_consent
+          @consent = Consent.find(params[:id])
+          authorize(@consent)
+        end
     end
   end
 end

--- a/app/controllers/challenges/dashboard/evaluators/metrics_controller.rb
+++ b/app/controllers/challenges/dashboard/evaluators/metrics_controller.rb
@@ -41,17 +41,17 @@ module Challenges
         end
 
         private
-        def set_evaluator
-          @evaluator = Evaluator.find(params[:evaluator_id])
-        end
+          def set_evaluator
+            @evaluator = Evaluator.find(params[:evaluator_id])
+          end
 
-        def set_metric
-          @metric = Metric.find(params[:id])
-        end
+          def set_metric
+            @metric = Metric.find(params[:id])
+          end
 
-        def metric_params
-          params.require(:metric).permit(:name, :order, :worst_score, :best_score)
-        end
+          def metric_params
+            params.require(:metric).permit(:name, :order, :worst_score, :best_score)
+          end
       end
     end
   end

--- a/app/controllers/challenges/dashboard/evaluators_controller.rb
+++ b/app/controllers/challenges/dashboard/evaluators_controller.rb
@@ -45,14 +45,14 @@ module Challenges
       end
 
       private
-      def evaluator_params
-        params.required(:evaluator).permit(:name, :script, :host, :from, :to)
-      end
+        def evaluator_params
+          params.required(:evaluator).permit(:name, :script, :host, :from, :to)
+        end
 
-      def find_and_authorize_evaluator
-        @evaluator = policy_scope(Evaluator).find(params[:id])
-        authorize(@evaluator)
-      end
+        def find_and_authorize_evaluator
+          @evaluator = policy_scope(Evaluator).find(params[:id])
+          authorize(@evaluator)
+        end
     end
   end
 end

--- a/app/controllers/challenges/dashboard/test_sets_controller.rb
+++ b/app/controllers/challenges/dashboard/test_sets_controller.rb
@@ -48,7 +48,6 @@ module Challenges
         end
       end
 
-
       private
         def test_set_params
           params.expect(test_set: [

--- a/app/controllers/challenges/evaluations/scores_controller.rb
+++ b/app/controllers/challenges/evaluations/scores_controller.rb
@@ -16,7 +16,7 @@ module Challenges
       end
 
       def metrics
-      @evaluation.metrics.map(&:name)
+        @evaluation.metrics.map(&:name)
       end
     end
   end

--- a/app/controllers/challenges/submissions/hypotheses_controller.rb
+++ b/app/controllers/challenges/submissions/hypotheses_controller.rb
@@ -27,9 +27,9 @@ module Challenges
       end
 
       private
-      def hypothesis_params
-        params.require(:hypothesis).permit(:test_set_entry_id, :input)
-      end
+        def hypothesis_params
+          params.require(:hypothesis).permit(:test_set_entry_id, :input)
+        end
     end
   end
 end

--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -219,7 +219,6 @@ module IconsHelper
     .html_safe
   end
 
-
   def color_picker_icon(css_classes = "")
     <<~SVG
       <svg class="#{css_classes}" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/app/jobs/evaluations/update_status_job.rb
+++ b/app/jobs/evaluations/update_status_job.rb
@@ -16,36 +16,36 @@ module Evaluations
     end
 
     private
-    def submitted_evaluations
-      @submitted_evaluations ||= Evaluation.joins(:evaluator)
-        .where(
-          creator: @user,
-          evaluations: { status: [ :pending, :running ] },
-          evaluator: { host: @host }
-        )
-    end
-
-    def update_evaluations(statuses)
-      statuses = statuses.transform_keys(&:to_s)
-      submitted_evaluations.each do |evaluation|
-        evaluation.update job_status: statuses[evaluation.job_id]
+      def submitted_evaluations
+        @submitted_evaluations ||= Evaluation.joins(:evaluator)
+          .where(
+            creator: @user,
+            evaluations: { status: [ :pending, :running ] },
+            evaluator: { host: @host }
+          )
       end
-    end
 
-    def log_error(user, code, message)
-      Rails.logger.tagged(self.class.name) do
-        Rails.logger.warn(
-          "Error while updating evaluations for #{user.plgrid_login}: #{code} #{message}"
-        )
+      def update_evaluations(statuses)
+        statuses = statuses.transform_keys(&:to_s)
+        submitted_evaluations.each do |evaluation|
+          evaluation.update job_status: statuses[evaluation.job_id]
+        end
       end
-    end
 
-    def client
-      @client ||= Mltop.hpc_client(@user, @host)
-    end
+      def log_error(user, code, message)
+        Rails.logger.tagged(self.class.name) do
+          Rails.logger.warn(
+            "Error while updating evaluations for #{user.plgrid_login}: #{code} #{message}"
+          )
+        end
+      end
 
-    def check_statuses(user)
-      Hpc::Response.new(request: client.jobs)
-    end
+      def client
+        @client ||= Mltop.hpc_client(@user, @host)
+      end
+
+      def check_statuses(user)
+        Hpc::Response.new(request: client.jobs)
+      end
   end
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -29,7 +29,7 @@ class Current < ActiveSupport::CurrentAttributes
 
   private
 
-  def find_membership
-    self.membership = Membership.find_by(user:, challenge:) if user && challenge
-  end
+    def find_membership
+      self.membership = Membership.find_by(user:, challenge:) if user && challenge
+    end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -8,7 +8,6 @@ class Membership < ApplicationRecord
   validate :satisfies_access_rules
   roles AccessRule.valid_roles
 
-
   def update_role
     challenge.update_membership(self)
   end

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -11,12 +11,12 @@ class Metric < ApplicationRecord
   }
 
   private
-  def proper_score_range
-    if asc? && best_score >= worst_score
-      errors.add(:best_score, "Best score has to be lesser than worst score")
+    def proper_score_range
+      if asc? && best_score >= worst_score
+        errors.add(:best_score, "Best score has to be lesser than worst score")
+      end
+      if desc? && best_score <= worst_score
+        errors.add(:best_score, "Best score has to be greater than worst score")
+      end
     end
-    if desc? && best_score <= worst_score
-      errors.add(:best_score, "Best score has to be greater than worst score")
-    end
-  end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -38,50 +38,75 @@ class ApplicationPolicy
 
   private
 
-  def challenge_open?
-    Time.current.between?(Current.challenge.starts_at, Current.challenge.ends_at)
-  end
-
-  def challenge_editor?
-    Current.challenge&.owner == user
-  end
-
-  def challenge_manager?
-    Current.membership&.manager?
-  end
-
-  def admin?
-    user&.admin?
-  end
-
-  def challenge_participant?
-    Current.challenge_member?
-  end
-
-  def meetween_member?
-    Current.user.meetween_member?
-  end
-
-  def leaderboard_released?
-    Current.challenge.leaderboard_released?
-  end
-
-  class Scope
-    def initialize(user, scope)
-      @user = user
-      @scope = scope
+    def challenge_open?
+      Time.current.between?(Current.challenge.starts_at, Current.challenge.ends_at)
     end
 
-    def resolve
-      raise NotImplementedError, "You must define #resolve in #{self.class}"
+    def challenge_editor?
+      Current.challenge&.owner == user
+    end
+
+    def challenge_manager?
+      Current.membership&.manager?
+    end
+
+    def admin?
+      user&.admin?
+    end
+
+    def challenge_participant?
+      Current.challenge_member?
+    end
+
+    def meetween_member?
+      Current.user.meetween_member?
     end
 
     def leaderboard_released?
       Current.challenge.leaderboard_released?
     end
 
-    private
+    class Scope
+      def initialize(user, scope)
+        @user = user
+        @scope = scope
+      end
 
-    attr_reader :user, :scope
-  end
+      def admin_or_challenge_editor?
+        user.admin? || Current.challenge&.owner == user
+      end
+
+      def leaderboard_released?
+        Current.challenge.leaderboard_released?
+      end
+
+      private
+
+        def admin?
+          user&.admin?
+        end
+
+        def challenge_participant?
+          Current.challenge_member?
+        end
+
+        def meetween_member?
+          Current.user.meetween_member?
+        end
+
+        class Scope
+          def initialize(user, scope)
+            @user = user
+            @scope = scope
+          end
+
+          def resolve
+            raise NotImplementedError, "You must define #resolve in #{self.class}"
+          end
+
+          private
+
+            attr_reader :user, :scope
+        end
+    end
 end

--- a/app/policies/challenges/dashboard/consent_policy.rb
+++ b/app/policies/challenges/dashboard/consent_policy.rb
@@ -41,9 +41,9 @@ module Challenges
 
       private
 
-      def challenge_maintainer?
-        user.admin? || (user == record.challenge.owner && user.meetween_member?)
-      end
+        def challenge_maintainer?
+          user.admin? || (user == record.challenge.owner && user.meetween_member?)
+        end
     end
   end
 end

--- a/lib/form_builders/tailwind_form_builder.rb
+++ b/lib/form_builders/tailwind_form_builder.rb
@@ -109,74 +109,74 @@ module FormBuilders
 
     private
 
-    def text_like_field(field_method, object_method, options = {})
-      custom_opts, opts = partition_custom_opts(options)
+      def text_like_field(field_method, object_method, options = {})
+        custom_opts, opts = partition_custom_opts(options)
 
-      classes = apply_style_classes(TEXT_FIELD_STYLE, custom_opts, object_method)
+        classes = apply_style_classes(TEXT_FIELD_STYLE, custom_opts, object_method)
 
-      field = send(field_method, object_method, {
-        class: classes,
-        title: errors_for(object_method)&.join(" ")
-      }.compact.merge(opts).merge(tailwindified: true))
+        field = send(field_method, object_method, {
+          class: classes,
+          title: errors_for(object_method)&.join(" ")
+        }.compact.merge(opts).merge(tailwindified: true))
 
-      label = item_label(object_method, custom_opts[:label], options)
+        label = item_label(object_method, custom_opts[:label], options)
 
-      @template.content_tag "div", class: custom_opts[:wrapper] do
-        label + field + error_label(object_method)
-      end
-    end
-
-    def item_label(object_method, label_options, field_options)
-      label = tailwind_label(object_method, label_options, field_options)
-      @template.content_tag("div", label, class: "flex flex-col items-start")
-    end
-
-    def tailwind_label(object_method, label_options, field_options)
-      text, label_opts = if label_options.present?
-        [ label_options[:text], label_options.except(:text) ]
-      else
-        [ nil, {} ]
+        @template.content_tag "div", class: custom_opts[:wrapper] do
+          label + field + error_label(object_method)
+        end
       end
 
-      label_classes = label_opts[:class] || "block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4"
-      label_classes += " text-yellow-800 dark:text-yellow-400" if field_options[:disabled]
-      label(object_method, text, {
-        class: label_classes
-      }.merge(label_opts.except(:class)))
-    end
-
-    def error_label(object_method, options = {})
-      if errors_for(object_method).present?
-        error_message = @object.errors[object_method].collect(&:titleize).join(", ")
-        tailwind_label(object_method, { text: error_message, class: " font-bold text-red-500" }, options)
+      def item_label(object_method, label_options, field_options)
+        label = tailwind_label(object_method, label_options, field_options)
+        @template.content_tag("div", label, class: "flex flex-col items-start")
       end
-    end
 
-    def border_color_classes(object_method)
-      if errors_for(object_method).present?
-        "border-2 border-red-400 focus:border-rose-200"
-      else
-        "border border-gray-300 focus:border-yellow-700"
+      def tailwind_label(object_method, label_options, field_options)
+        text, label_opts = if label_options.present?
+          [ label_options[:text], label_options.except(:text) ]
+        else
+          [ nil, {} ]
+        end
+
+        label_classes = label_opts[:class] || "block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4"
+        label_classes += " text-yellow-800 dark:text-yellow-400" if field_options[:disabled]
+        label(object_method, text, {
+          class: label_classes
+        }.merge(label_opts.except(:class)))
       end
-    end
 
-    def apply_style_classes(classes, custom_opts, object_method = nil)
-      join_classes(classes, border_color_classes(object_method), custom_opts[:class])
-    end
+      def error_label(object_method, options = {})
+        if errors_for(object_method).present?
+          error_message = @object.errors[object_method].collect(&:titleize).join(", ")
+          tailwind_label(object_method, { text: error_message, class: " font-bold text-red-500" }, options)
+        end
+      end
 
-    def join_classes(*classes)
-      classes.compact.join(" ")
-    end
+      def border_color_classes(object_method)
+        if errors_for(object_method).present?
+          "border-2 border-red-400 focus:border-rose-200"
+        else
+          "border border-gray-300 focus:border-yellow-700"
+        end
+      end
 
-    CUSTOM_OPTS = [ :label, :class, :wrapper ].freeze
-    def partition_custom_opts(opts)
-      opts.partition { |k, v| CUSTOM_OPTS.include?(k) }.map(&:to_h)
-    end
+      def apply_style_classes(classes, custom_opts, object_method = nil)
+        join_classes(classes, border_color_classes(object_method), custom_opts[:class])
+      end
 
-    def errors_for(object_method)
-      return unless @object.present? && object_method.present?
+      def join_classes(*classes)
+        classes.compact.join(" ")
+      end
 
-      @object.errors[object_method]
-    end
+      CUSTOM_OPTS = [ :label, :class, :wrapper ].freeze
+      def partition_custom_opts(opts)
+        opts.partition { |k, v| CUSTOM_OPTS.include?(k) }.map(&:to_h)
+      end
+
+      def errors_for(object_method)
+        return unless @object.present? && object_method.present?
+
+        @object.errors[object_method]
+      end
   end
 end

--- a/lib/test_set_loader/processor.rb
+++ b/lib/test_set_loader/processor.rb
@@ -150,7 +150,6 @@ class TestSetLoader::Processor
       blob&.checksum != ActiveStorage::Blob.new.send(:compute_checksum_in_chunks, io.open)
     end
 
-
     def task
       @task ||= Task.find_by!(slug:)
     end

--- a/lib/test_set_loader/slu_processor.rb
+++ b/lib/test_set_loader/slu_processor.rb
@@ -11,21 +11,21 @@ class TestSetLoader::SluProcessor < TestSetLoader::Processor
 
   private
 
-  def process_speech_massive(dir)
-    single_language_process(dir) do |entry, _name, lang|
-      [
-        child_with_extension(entry, "#{lang}_audios.tar.gz"),
-        child_with_extension(entry, ".#{lang}")
-      ]
+    def process_speech_massive(dir)
+      single_language_process(dir) do |entry, _name, lang|
+        [
+          child_with_extension(entry, "#{lang}_audios.tar.gz"),
+          child_with_extension(entry, ".#{lang}")
+        ]
+      end
     end
-  end
 
-  def process_slurp(dir)
-    single_language_process(dir) do |entry, _name, lang|
-      [
-        child_with_extension(entry, "en_audios.tar.gz"),
-        child_with_extension(entry, ".en")
-      ]
+    def process_slurp(dir)
+      single_language_process(dir) do |entry, _name, lang|
+        [
+          child_with_extension(entry, "en_audios.tar.gz"),
+          child_with_extension(entry, ".en")
+        ]
+      end
     end
-  end
 end

--- a/test/controllers/challenges/dashboard/test_sets/entries_controller.rb
+++ b/test/controllers/challenges/dashboard/test_sets/entries_controller.rb
@@ -1,6 +1,5 @@
 require "test_helper"
 
-
 class Challenges::Dashboard::TestSets::EntriesControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in_as("marek")

--- a/test/controllers/challenges/submissions/hypothesis_controller_test.rb
+++ b/test/controllers/challenges/submissions/hypothesis_controller_test.rb
@@ -2,44 +2,44 @@ require "test_helper"
 module Challenges
   module Submissions
     class HypothesesControllerTest < ActionDispatch::IntegrationTest
-    def setup
-      in_challenge!
-      sign_in_as("marek")
-      @model = create(:model, owner: users("marek"))
-      @task = @model.tasks.first
-      @test_set_entry = test_set_entries("flores_st_en_it")
-    end
-
-    test "should create hypotheses" do
-      assert_difference("Hypothesis.count") do
-        post submission_hypotheses_path(submission_id: @model.id, format: :turbo_stream),
-          params: { hypothesis: { test_set_entry_id: @test_set_entry.id, model_id: @model.id, input: fixture_file_upload("input.txt") } }
+      def setup
+        in_challenge!
+        sign_in_as("marek")
+        @model = create(:model, owner: users("marek"))
+        @task = @model.tasks.first
+        @test_set_entry = test_set_entries("flores_st_en_it")
       end
 
-      assert_response :ok
-      assert_equal "Hypothesis succesfully created", flash[:notice]
-    end
+      test "should create hypotheses" do
+        assert_difference("Hypothesis.count") do
+          post submission_hypotheses_path(submission_id: @model.id, format: :turbo_stream),
+            params: { hypothesis: { test_set_entry_id: @test_set_entry.id, model_id: @model.id, input: fixture_file_upload("input.txt") } }
+        end
 
-    test "it returns uprocessable for invalid params" do
-      @hypothesis = create(:hypothesis, model: @model, test_set_entry: @test_set_entry)
-
-      assert_no_difference("Hypothesis.count") do
-        post submission_hypotheses_path(submission_id: @model.id, format: :turbo_stream),
-          params: { hypothesis: { test_set_entry_id: @test_set_entry.id, model_id: @model.id, input: fixture_file_upload("input.txt") } }
+        assert_response :ok
+        assert_equal "Hypothesis succesfully created", flash[:notice]
       end
 
-      assert_equal "Unable to create hypothesis", flash[:alert]
-    end
+      test "it returns uprocessable for invalid params" do
+        @hypothesis = create(:hypothesis, model: @model, test_set_entry: @test_set_entry)
 
-    test "should delete hypothesis" do
-      @hypothesis = create(:hypothesis, model: @model, test_set_entry: @test_set_entry)
-      assert_difference("Hypothesis.count", -1) do
-        delete hypothesis_path(id: @hypothesis.id, format: :turbo_stream)
+        assert_no_difference("Hypothesis.count") do
+          post submission_hypotheses_path(submission_id: @model.id, format: :turbo_stream),
+            params: { hypothesis: { test_set_entry_id: @test_set_entry.id, model_id: @model.id, input: fixture_file_upload("input.txt") } }
+        end
+
+        assert_equal "Unable to create hypothesis", flash[:alert]
       end
 
-      assert_response :ok
-      assert_equal "Hypothesis succesfully deleted", flash[:notice]
-    end
+      test "should delete hypothesis" do
+        @hypothesis = create(:hypothesis, model: @model, test_set_entry: @test_set_entry)
+        assert_difference("Hypothesis.count", -1) do
+          delete hypothesis_path(id: @hypothesis.id, format: :turbo_stream)
+        end
+
+        assert_response :ok
+        assert_equal "Hypothesis succesfully deleted", flash[:notice]
+      end
     end
   end
 end

--- a/test/controllers/challenges_controller_test.rb
+++ b/test/controllers/challenges_controller_test.rb
@@ -14,10 +14,10 @@ class ChallengesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show" do
-    sign_in_as(:marek)
-    get challenge_path(@challenge)
-    assert_response :success
-    assert_includes response.body, @challenge.name
+  sign_in_as(:marek)
+  get challenge_path(@challenge)
+  assert_response :success
+  assert_includes response.body, @challenge.name
 end
   test "#new denied access for normal user" do
     sign_in_as(:external, teams: nil)

--- a/test/controllers/challenges_controller_test.rb
+++ b/test/controllers/challenges_controller_test.rb
@@ -6,19 +6,23 @@ class ChallengesControllerTest < ActionDispatch::IntegrationTest
   def setup
     @challenge = create(:challenge)
   end
+
   test "#index" do
     sign_in_as(:marek)
     get challenges_path
+
     assert_response :success
     assert_includes response.body, @challenge.name
   end
 
   test "#show" do
-  sign_in_as(:marek)
-  get challenge_path(@challenge)
-  assert_response :success
-  assert_includes response.body, @challenge.name
-end
+    sign_in_as(:marek)
+    get challenge_path(@challenge)
+
+    assert_response :success
+    assert_includes response.body, @challenge.name
+  end
+
   test "#new denied access for normal user" do
     sign_in_as(:external, teams: nil)
     get new_challenge_path
@@ -51,10 +55,10 @@ end
 
   test "should destroy challenge" do
     sign_in_as(:marek)
+
     assert_difference("Challenge.count", -1) do
       delete challenge_path(@challenge)
     end
-
     assert_redirected_to challenges_path
   end
 end

--- a/test/jobs/evaluations/run_job_test.rb
+++ b/test/jobs/evaluations/run_job_test.rb
@@ -9,7 +9,7 @@ module Evaluations
 
     test "submits evaluations" do
       stub_ssh_connection
-      Evaluation.any_instance.stubs(:run).returns(true)
+      Evaluation.any_instance.expects(:run).returns(true)
       RunJob.perform_now(evaluations: [ @evaluation ], user: @user)
     end
 

--- a/test/jobs/evaluations/run_job_test.rb
+++ b/test/jobs/evaluations/run_job_test.rb
@@ -15,14 +15,14 @@ module Evaluations
 
     private
 
-    def stub_ssh_connection
-      HPCKit::Slurm::Backends::Netssh.stubs(:new)
-      @restd = Minitest::Mock.new
-      @restd_runner = Minitest::Mock.new
-      HPCKit::Slurm::Restd.stubs(:new).returns(@restd)
-      @restd.expect(:start, nil) do |&block|
-        block.call(@restd_runner)
+      def stub_ssh_connection
+        HPCKit::Slurm::Backends::Netssh.stubs(:new)
+        @restd = Minitest::Mock.new
+        @restd_runner = Minitest::Mock.new
+        HPCKit::Slurm::Restd.stubs(:new).returns(@restd)
+        @restd.expect(:start, nil) do |&block|
+          block.call(@restd_runner)
+        end
       end
-    end
   end
 end

--- a/test/jobs/evaluations/update_status_job_test.rb
+++ b/test/jobs/evaluations/update_status_job_test.rb
@@ -37,7 +37,6 @@ module Evaluations
       end
     end
 
-
     test "does not call hpc client when evaluations are not running" do
       evaluation1 = create(:evaluation, job_id: "1", status: :completed, creator: users("marek"))
 

--- a/test/models/challenge/roles_manager_test.rb
+++ b/test/models/challenge/roles_manager_test.rb
@@ -8,7 +8,6 @@ class Challenge::RolesManagerTest < ActiveSupport::TestCase
     @membership = create(:membership, user: @user, challenge: @challenge, roles: [ :manager ])
   end
 
-
   test "membership should be deleted when it was only one granting user access" do
     @access_rule.update(group_name: "new name")
 
@@ -35,7 +34,6 @@ class Challenge::RolesManagerTest < ActiveSupport::TestCase
 
     assert @membership.reload.manager?
   end
-
 
   test "other group created with participant, membership stays as is" do
     @user.update(groups: [ "old name", "other group" ])
@@ -82,7 +80,6 @@ class Challenge::RolesManagerTest < ActiveSupport::TestCase
 
     assert @membership.manager?
   end
-
 
   test "#update_membership other group created with participant, membership stays as is" do
     @user.update(groups: [ "old name", "other group" ])

--- a/test/models/challenge/roles_manager_test.rb
+++ b/test/models/challenge/roles_manager_test.rb
@@ -56,13 +56,13 @@ class Challenge::RolesManagerTest < ActiveSupport::TestCase
     assert @membership.reload.manager?
   end
 
-   test "#update_membership membership should be deleted when it was only one granting user access" do
-    @access_rule.update(group_name: "new name")
+  test "#update_membership membership should be deleted when it was only one granting user access" do
+   @access_rule.update(group_name: "new name")
 
-    assert_changes "Membership.count", -1 do
-      @challenge.update_membership(@membership)
-    end
-  end
+   assert_changes "Membership.count", -1 do
+     @challenge.update_membership(@membership)
+   end
+ end
 
   test "#update_membership name changes, but user still has access from other group - membership should stay as is" do
     @user.update(groups: [ "old name", "other group" ])

--- a/test/models/evaluation_test.rb
+++ b/test/models/evaluation_test.rb
@@ -56,7 +56,6 @@ class EvaluationTest < ActiveSupport::TestCase
     end
   end
 
-
   test "successful started evaluation changes status to running" do
     Hpc::ClientMock.stub_submit
 

--- a/test/models/top/row_test.rb
+++ b/test/models/top/row_test.rb
@@ -55,7 +55,7 @@ class Top::RowTest < ActiveSupport::TestCase
     new_evaluation(model, :flores_st_pl_en, 4.5)
     row = Top::Row.where(task: tasks(:st), source: "en").first
     assert_equal 2, row.score(test_set: test_sets(:flores), metric: metrics(:blueurt)).value,
-  "Wrong score: (4 (en->pl) + 2 (en->it) + 0 (en->de)) / 3 = 2, pl->en not included"
+      "Wrong score: (4 (en->pl) + 2 (en->it) + 0 (en->de)) / 3 = 2, pl->en not included"
 
     new_evaluation(model, :flores_st_en_de, 6)
     row = Top::Row.where(task: tasks(:st), source: "en").first
@@ -79,8 +79,8 @@ class Top::RowTest < ActiveSupport::TestCase
 
     assert_nil row.score(test_set: test_sets(:flores),
                          metric: metrics(:blueurt),
-                         test_set_entry: test_set_entries(:flores_st_en_it)).value
-    "Nil score should be created when no score in DB"
+                         test_set_entry: test_set_entries(:flores_st_en_it)).value,
+      "Nil score should be created when no score in DB"
   end
 
   test "order" do

--- a/test/models/top/row_test.rb
+++ b/test/models/top/row_test.rb
@@ -54,8 +54,8 @@ class Top::RowTest < ActiveSupport::TestCase
 
     new_evaluation(model, :flores_st_pl_en, 4.5)
     row = Top::Row.where(task: tasks(:st), source: "en").first
-        assert_equal 2, row.score(test_set: test_sets(:flores), metric: metrics(:blueurt)).value,
-      "Wrong score: (4 (en->pl) + 2 (en->it) + 0 (en->de)) / 3 = 2, pl->en not included"
+    assert_equal 2, row.score(test_set: test_sets(:flores), metric: metrics(:blueurt)).value,
+  "Wrong score: (4 (en->pl) + 2 (en->it) + 0 (en->de)) / 3 = 2, pl->en not included"
 
     new_evaluation(model, :flores_st_en_de, 6)
     row = Top::Row.where(task: tasks(:st), source: "en").first
@@ -80,7 +80,7 @@ class Top::RowTest < ActiveSupport::TestCase
     assert_nil row.score(test_set: test_sets(:flores),
                          metric: metrics(:blueurt),
                          test_set_entry: test_set_entries(:flores_st_en_it)).value
-              "Nil score should be created when no score in DB"
+    "Nil score should be created when no score in DB"
   end
 
   test "order" do

--- a/test/support/hpc/client_mock.rb
+++ b/test/support/hpc/client_mock.rb
@@ -38,12 +38,12 @@ class Hpc::ClientMock
 
   private
 
-  class RequestMock
-    def initialize(code:, body:)
-      @code = code
-      @body = body
-    end
+    class RequestMock
+      def initialize(code:, body:)
+        @code = code
+        @body = body
+      end
 
-    attr_reader :code, :body
-  end
+      attr_reader :code, :body
+    end
 end


### PR DESCRIPTION
Adds identation and empty lines cops, adds missing assertions in test. Fixes deprecated unprocessable_entity
Why omakase has this cops disabled? from their [rubocop.yml](https://github.com/rails/rubocop-rails-omakase/blob/main/rubocop.yml)
```
# Method definitions after `private` or `protected` isolated calls need one
# extra level of indentation.
#
# We break this rule in context, though, e.g. for private-only concerns,
# so we leave it disabled.
Layout/IndentationConsistency:
Enabled: false
```
```
# Doesn't behave properly with private-only concerns, so it's disabled.
Layout/IndentationWidth:
  Enabled: false
```

didnt find a reason for empty lines cop