### PR TITLE
Fetch ssh certificate for all plgrid users

### DIFF
--- a/app/models/sso/plgrid.rb
+++ b/app/models/sso/plgrid.rb
@@ -13,9 +13,7 @@ module Sso
       @email = auth.info["email"]
       @plgrid_login = auth.info["nickname"]
 
-      if meetween_member?
-        fetch_short_lived_ssh_credentials!(auth.dig("credentials", "token"))
-      end
+      fetch_short_lived_ssh_credentials!(auth.dig("credentials", "token"))
     end
 
     def to_user

--- a/test/models/sso/plgrid_test.rb
+++ b/test/models/sso/plgrid_test.rb
@@ -5,35 +5,17 @@ require "ostruct"
 
 module Sso
   class PlgridTest < ActiveSupport::TestCase
-    test "plgrid login uses auth info and CCM to populate user data for meetween members" do
+    test "plgrid login uses auth info and CCM to populate user data" do
       plgrid_user = Sso::Plgrid.from_omniauth(auth("plgnewuser",
         token: CcmHelpers::VALID_TOKEN,
-        groups: [ "plggmeetween", "other", "group" ]))
+        groups: [ "group1", "group2" ]))
 
       attrs = {
         name: "plgnewuser Last Name",
         email: "plgnewuser@b.c",
         plgrid_login: "plgnewuser",
-        roles_mask: ::User.new(roles: [ :meetween_member ]).roles_mask,
         ssh_key: CredentialsProvider.key,
         ssh_certificate: CredentialsProvider.cert
-      }
-
-      assert_user_attrs_equal attrs, plgrid_user
-    end
-
-    test "plgrid login uses only auth info to populate user data for non-meetween members" do
-      plgrid_user = Sso::Plgrid.from_omniauth(auth("plgnewuser",
-        token: CcmHelpers::VALID_TOKEN,
-        groups: [ "other", "group" ]))
-
-      attrs = {
-        name: "plgnewuser Last Name",
-        email: "plgnewuser@b.c",
-        plgrid_login: "plgnewuser",
-        roles_mask: ::User.new(roles: []).roles_mask,
-        ssh_key: nil,
-        ssh_certificate: nil
       }
 
       assert_user_attrs_equal attrs, plgrid_user


### PR DESCRIPTION
There are many situation when user can be promoted to manager, e.g. when a new `AccessRule` is created, that just for the simplicity ssh certificate is fetched and stored for all PLGrid users.