### PR TITLE
Remove meetween_member and user manager role instead

### DIFF
--- a/app/controllers/challenges/evaluations_controller.rb
+++ b/app/controllers/challenges/evaluations_controller.rb
@@ -33,7 +33,8 @@ module Challenges
       end
 
       def my_or_external_models
-        Model.external.or(Model.where(owner: Current.user))
+        policy_scope(Model).external.or(
+          policy_scope(Model).where(owner: Current.user))
       end
   end
 end

--- a/app/controllers/challenges/submissions/evaluations_controller.rb
+++ b/app/controllers/challenges/submissions/evaluations_controller.rb
@@ -22,7 +22,8 @@ module Challenges
         end
 
         def my_or_external_models
-          Model.external.or(Model.where(owner: Current.user))
+          policy_scope(Model).external.or(
+            policy_scope(Model).where(owner: Current.user))
         end
     end
   end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -35,7 +35,7 @@ module Authentication
     def restore_authentication
       user = User.find_by(id: cookies.signed[:user_id])
 
-      if user && (!user.meetween_member? || user.credentials_valid?)
+      if user && (!user.from_plgrid? || user.credentials_valid?)
         authenticated_as(user)
       end
     end

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -15,16 +15,10 @@ class Challenge < ApplicationRecord
   validates :name, :starts_at, :ends_at, presence: true
   validates :ends_at, comparison: { greater_than: :starts_at }
 
-  validate :meetween_owner
-
   VISIBILITIES = { leaderboard_released: "leaderboard_released", scores_released: "scores_released" }
   enum :visibility, VISIBILITIES
 
   def to_s = name
-
-  def meetween_owner
-    errors.add(:owner, "not a meetween member") unless owner.meetween_member?
-  end
 
   def status
     now = Time.current

--- a/app/models/sso/plgrid.rb
+++ b/app/models/sso/plgrid.rb
@@ -19,7 +19,6 @@ module Sso
     def to_user
       if @uid
         User.find_or_initialize_by(provider: "plgrid", uid: @uid).tap do |user|
-          meetween_member? ? user.roles.add(:meetween_member) : user.roles.delete(:meetween_member)
           user.assign_attributes(attributes)
           user.save
           update_memberships(user) if user.groups_previously_changed?
@@ -28,10 +27,6 @@ module Sso
     end
 
     private
-      def meetween_member?
-        @teams.include?("plggmeetween")
-      end
-
       def attributes
         {
           name: @name,

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -58,10 +58,6 @@ class ApplicationPolicy
       Current.challenge_member?
     end
 
-    def meetween_member?
-      Current.user.meetween_member?
-    end
-
     def leaderboard_released?
       Current.challenge.leaderboard_released?
     end
@@ -84,10 +80,6 @@ class ApplicationPolicy
 
         def challenge_participant?
           Current.challenge_member?
-        end
-
-        def meetween_member?
-          Current.user.meetween_member?
         end
 
         class Scope

--- a/app/policies/challenges/dashboard/consent_policy.rb
+++ b/app/policies/challenges/dashboard/consent_policy.rb
@@ -8,42 +8,36 @@ module Challenges
       end
 
       def index?
-        user.meetween_member?
+        challenge_admin?
       end
 
       def show?
-        user.meetween_member?
+        challenge_admin?
       end
 
       def new?
-        user.meetween_member?
+        challenge_admin?
       end
 
       def create?
-        user.meetween_member?
+        challenge_admin?
       end
 
       def edit?
-        challenge_maintainer?
+        challenge_admin?
       end
 
       def update?
-        challenge_maintainer?
+        challenge_admin?
       end
 
       def destroy?
-        challenge_maintainer?
+        challenge_admin?
       end
 
       def permitted_attributes
         [ :name, :description, :mandatory, :target ]
       end
-
-      private
-
-        def challenge_maintainer?
-          user.admin? || (user == record.challenge.owner && user.meetween_member?)
-        end
     end
   end
 end

--- a/app/policies/challenges/dashboard/model_policy.rb
+++ b/app/policies/challenges/dashboard/model_policy.rb
@@ -8,7 +8,7 @@ module Challenges
       end
 
       def index?
-        meetween_member?
+        challenge_manager?
       end
     end
   end

--- a/app/views/challenges/submissions/hypotheses/_hypothesis.html.erb
+++ b/app/views/challenges/submissions/hypotheses/_hypothesis.html.erb
@@ -26,7 +26,7 @@
           <% end %>
         </div>
         <div class="ml-4 mt-2 flex shrink-0">
-          <% if Current.user.meetween_member? && !hypothesis.fully_evaluated? %>
+          <% if Current.challenge_manager? && !hypothesis.fully_evaluated? %>
             <%= button_to hypothesis_evaluations_path(hypothesis), class: "text-emerald-600 hover:text-white hover:bg-emerald-600 relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-medium ring-1 ring-inset ring-gray-300 mr-3" do %>
               <%= run_icon("ml-0.5 mr-1.5 h-5 w-5") %>
               <span>Evaluate all</span>
@@ -94,9 +94,9 @@
               <%= alert_icon("size-5 text-yellow-400") %>
             </div>
             <div class="ml-3">
-              <h3 class="text-sm font-medium text-yellow-800">Submission will be reviewed by Meetween members</h3>
+              <h3 class="text-sm font-medium text-yellow-800">Submission will be reviewed by challenge managers</h3>
               <div class="mt-2 text-sm text-yellow-700">
-                <p>Your submission need to be approved by one the Meetween members. Once reviewed the hypothesis scores will be calculated.</p>
+                <p>Your submission need to be approved by one challenge managers. Once reviewed the hypothesis scores will be calculated.</p>
               </div>
             </div>
           </div>

--- a/config/initializers/role_model_ext.rb
+++ b/config/initializers/role_model_ext.rb
@@ -1,0 +1,7 @@
+module RoleModel
+  module ClassMethods
+    def without_role(*roles)
+      (arel_table[:roles_mask] & mask_for(roles)).eq(0)
+    end
+  end
+end

--- a/db/migrate/20250820093414_remove_meetween_member_role_from_user.rb
+++ b/db/migrate/20250820093414_remove_meetween_member_role_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveMeetweenMemberRoleFromUser < ActiveRecord::Migration[8.0]
+  def up
+    execute "UPDATE users SET roles_mask = roles_mask & ~2 WHERE roles_mask & 2 != 0"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_11_094141) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_20_093414) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -13,7 +13,7 @@ if Rails.env.local?
       uid = ENV["UID"] || raise("Please put your keycloak UID to .env file (echo \"UID=my-uid\" >> .env)")
       user = User.create!(uid:, plgrid_login: "will-be-updated", provider: "plgrid",
                         email: "will@be.updated",
-                        roles: [ :admin, :meetween_member ])
+                        roles: [ :admin ])
       challenge = Challenge.create!(name: "Meetween Global Challenge",
                         starts_at: 5.days.ago,
                         ends_at: 1.month.from_now,

--- a/test/controllers/challenges/dashboard/external_submissions_controller_test.rb
+++ b/test/controllers/challenges/dashboard/external_submissions_controller_test.rb
@@ -19,6 +19,11 @@ module Challenges
       end
 
       test "Challenge manager can see only not evaluated external models" do
+        users("marek").update(groups: [ "plggmeetween" ])
+        users("external").update(groups: [ "plggother" ])
+        Membership.create(user: users("marek"), challenge: challenges(:global), roles: [ :manager ])
+        Membership.create(user: users("external"), challenge: challenges(:global), roles: [])
+
         empty_external_model = create(:model, owner: users("external"))
         external_model = create_not_evaluated_model(owner: users("external"))
         internal_model = create_not_evaluated_model(owner: users("marek"))

--- a/test/controllers/challenges/submissions/evaluations_controller_test.rb
+++ b/test/controllers/challenges/submissions/evaluations_controller_test.rb
@@ -35,7 +35,7 @@ module Challenges
       test "Challenge managers cannot start other managers model evaluation" do
         model =  create(:model, owner: users("szymon"))
         users(:szymon).update(groups: [ "plggmeetween" ])
-        create(:membership, user: users(:szymon), challenge: challenges(:global))
+        create(:membership, user: users(:szymon), challenge: challenges(:global), roles: [ "manager" ])
         hypothesis = create(:hypothesis, model:)
 
         challenge_member_signs_in("marek", challenges(:global), teams: [ "plggmeetween" ])
@@ -45,6 +45,8 @@ module Challenges
       end
 
       test "Challenge managers can start external users model evaluations" do
+        users("external").update(groups: [ "plggother" ])
+        create(:membership, user: users(:external), challenge: challenges(:global), roles: [])
         model =  create(:model, owner: users("external"))
         hypothesis = create(:hypothesis, model:)
 

--- a/test/controllers/challenges_controller_test.rb
+++ b/test/controllers/challenges_controller_test.rb
@@ -31,14 +31,14 @@ class ChallengesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "You are not authorized to perform this action", flash[:alert]
   end
 
-  test "#new for meetween member" do
+  test "#new for admin" do
     sign_in_as(:marek)
     get new_challenge_path
 
     assert_response :success
   end
 
-  test "#create for meetween member" do
+  test "admin can create a new challenge" do
     sign_in_as(:marek)
     challenge = build(:challenge)
 
@@ -55,7 +55,7 @@ class ChallengesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to challenge_path(Challenge.last)
   end
 
-  test "should destroy challenge" do
+  test "admin can remove challenge" do
     sign_in_as(:marek)
 
     assert_difference("Challenge.count", -1) do

--- a/test/controllers/evaluations_controller_test.rb
+++ b/test/controllers/evaluations_controller_test.rb
@@ -40,7 +40,7 @@ class EvaluationsControllerTest < ActionDispatch::IntegrationTest
   test "Managers cannot start other managers model evaluation" do
     model =  create(:model, owner: users(:szymon))
     users(:szymon).update(groups: [ "plggmeetween" ])
-    create(:membership, user: users(:szymon), challenge: challenges(:global))
+    create(:membership, user: users(:szymon), challenge: challenges(:global), roles: [ "manager" ])
     hypothesis = create(:hypothesis, model:)
 
     challenge_member_signs_in("marek", challenges(:global), teams: [ "plggmeetween" ])
@@ -56,6 +56,8 @@ class EvaluationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "Challenge managers can start external users model evaluations" do
+    users("external").update(groups: [ "plggother" ])
+    create(:membership, user: users(:external), challenge: challenges(:global), roles: [])
     model =  create(:model, owner: users("external"))
     hypothesis = create(:hypothesis, model:)
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,7 +4,7 @@ marek:
   plgrid_login: plgmarek
   uid: uid-marek
   provider: plgrid
-  roles_mask: <%= User.new(roles: [:admin, :meetween_member]).roles_mask %>
+  roles_mask: <%= User.new(roles: [ :admin ]).roles_mask %>
   ssh_key: "abc"
   ssh_certificate: "def"
 
@@ -14,7 +14,7 @@ szymon:
   plgrid_login: plgszymon
   uid: uid-szymon
   provider: plgrid
-  roles_mask: <%= User.new(roles: [:meetween_member]).roles_mask %>
+  roles_mask: <%= User.new(roles: []).roles_mask %>
   ssh_key: "abc"
   ssh_certificate: "def"
 

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -19,8 +19,8 @@ class SessionsTest < ActionDispatch::IntegrationTest
     assert_no_match "External submissions", response.body
   end
 
-  test "Meetween members session is scoped to ssh certificate validation" do
-    sign_in_as("marek", teams: [ "plggmeetween" ])
+  test "Plgrid members session is scoped to ssh certificate validation" do
+    sign_in_as("marek", teams: [ "plggother" ])
     in_challenge!
 
     get submissions_path

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -8,6 +8,11 @@ class ModelTest < ActiveSupport::TestCase
   end
 
   test "find all external models" do
+    users("marek").update(groups: [ "plggmeetween" ])
+    users("external").update(groups: [ "plggother" ])
+    Membership.create!(user: users("marek"), challenge: challenges(:global), roles: [ :manager ])
+    Membership.create!(user: users("external"), challenge: challenges(:global), roles: [])
+
     external = create(:model, owner: users("external"))
     create(:model, owner: users("marek"))
 

--- a/test/models/sso/plgrid_test.rb
+++ b/test/models/sso/plgrid_test.rb
@@ -27,28 +27,6 @@ module Sso
       end
     end
 
-    test "meetween users has meetween_member role" do
-      plgrid_user = Sso::Plgrid.from_omniauth(auth("plgnewuser",
-        token: CcmHelpers::VALID_TOKEN, groups: [ "plggmeetween" ]))
-
-      assert plgrid_user.to_user.meetween_member?
-    end
-
-    test "meetween_member role is removed when user does not belong to plggmeetween group" do
-      user = create(:user, uid: "plgexisting_user", roles: [ :meetween_member ], provider: "plgrid")
-      plgrid_user = Sso::Plgrid.from_omniauth(auth("plgexisting_user", token: CcmHelpers::VALID_TOKEN, groups: []))
-
-      assert_equal user.id, plgrid_user.to_user.id
-      assert_not plgrid_user.to_user.meetween_member?
-    end
-
-    test "non meetween users does not have meetween_member role" do
-      plgrid_user = Sso::Plgrid.from_omniauth(auth("plgnewuser",
-        token: CcmHelpers::VALID_TOKEN, groups: [ "plggother" ]))
-
-      assert_not plgrid_user.to_user.meetween_member?
-    end
-
     test "groups are membership are updated when user groups change" do
       user = create(:user, uid: "plgexisting_user", groups: [ "plggmeetween" ], provider: "plgrid")
       membership = create(:membership, user:, challenge: challenges(:global), roles: [ :manager ])

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -10,6 +10,14 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "external users" do
+    users("marek").update!(groups: [ "plggmeetween" ])
+    users("szymon").update!(groups: [ "plggother" ])
+    users("external").update!(groups: [ "plggother" ])
+
+    Membership.create!(user: users("marek"), challenge: challenges(:global), roles: [ :manager ])
+    Membership.create!(user: users("szymon"), challenge: challenges(:global), roles: [ :manager ])
+    Membership.create!(user: users("external"), challenge: challenges(:global), roles: [])
+
     assert_equal [ users("external") ], User.external
   end
 end


### PR DESCRIPTION
This is the first step of refactoring and cleaning. At the beginning `meetween_member` role was removed from the user. I know that some of the code can be further cleaned or fixed (e.g. permissions on the dashboard views). It was left for this PR clarity - I will be fixing this in the following PRs.