### PR TITLE
update hypo warning message

### DIFF
--- a/app/views/challenges/submissions/hypotheses/_hypothesis.html.erb
+++ b/app/views/challenges/submissions/hypotheses/_hypothesis.html.erb
@@ -96,7 +96,7 @@
             <div class="ml-3">
               <h3 class="text-sm font-medium text-yellow-800">Submission will be reviewed by challenge managers</h3>
               <div class="mt-2 text-sm text-yellow-700">
-                <p>Your submission need to be approved by one challenge managers. Once reviewed the hypothesis scores will be calculated.</p>
+                <p>Once reviewed the hypothesis scores will be calculated. Afterwards, the scores will be visible when challenge administrator updates visibility settings.</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Warning could be misleading for challenge managers, suggesting that they should see scores when they are calculated. The scores visibIlity depends solely on challenge visibility flag
Closes #241 