### PR TITLE
Separate sessions

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -33,7 +33,7 @@ module Authentication
     end
 
     def restore_authentication
-      user = User.find_by(id: cookies.signed[:user_id])
+      user = User.find_by(id: session[:user_id])
 
       if user && (!user.from_plgrid? || user.credentials_valid?)
         authenticated_as(user)
@@ -52,10 +52,10 @@ module Authentication
 
     def authenticated_as(user)
       Current.user = user
-      cookies.signed.permanent[:user_id] = { value: user.id, httpsonly: true, same_site: :lax }
+      session[:user_id] = user.id
     end
 
     def reset_authentication
-      cookies.delete(:user_id)
+      session.delete(:user_id)
     end
 end

--- a/config/initializers/sso.rb
+++ b/config/initializers/sso.rb
@@ -11,8 +11,18 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       host: Rails.application.credentials.dig(:sso, :plgrid, :host),
       realm: Rails.application.credentials.dig(:sso, :plgrid, :realm),
       identifier: Rails.application.credentials.dig(:sso, :plgrid, :identifier),
-      secret: Rails.application.credentials.dig(:sso, :plgrid, :secret),
-      redirect_uri: "#{Rails.application.credentials.dig(:sso, :plgrid, :redirect_uri_base)}/auth/plgrid/callback"
+      secret: Rails.application.credentials.dig(:sso, :plgrid, :secret)
+    },
+    setup: lambda { |env|
+      request = Rack::Request.new(env)
+
+      redirect_uri = [
+        Rails.application.credentials.dig(:sso, :plgrid, :redirect_uri_base),
+        request.script_name,
+        "/auth/plgrid/callback"
+      ].join
+
+      env["omniauth.strategy"].options[:client_options][:redirect_uri] = redirect_uri
     }
 
   provider :github,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,9 +62,9 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Authentication
-  direct(:plgrid_sign_in) { "/auth/plgrid" }
-  direct(:github_sign_in) { "/auth/github" }
-  direct(:google_sign_in) { "/auth/google_oauth2" }
+  direct(:plgrid_sign_in) { [ request.script_name, "/auth/plgrid" ].join }
+  direct(:github_sign_in) { [ request.script_name, "/auth/github" ].join }
+  direct(:google_sign_in) { [ request.script_name, "/auth/google_oauth2" ].join }
   get "auth/:provider/callback", to: "sessions#create"
   get "auth/failure", to: redirect("/")
   get "sign_in", to: "sessions#new", as: "sign_in"


### PR DESCRIPTION
This change introduces session separation between the root domain and challenges. This is the first step of session management improvements. Next step will be to have authentication separation (other for root and challenge), proxy certificate management and login/joining flow.

For now, it is a draft, because Google and GitHub IDPs configurations need to be changed - it will be done and tested shortly.