### PR TITLE
in dev rake, we can fake generate test sets

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,7 +1,7 @@
 if Rails.env.local?
   namespace :dev do
     desc "Sample data for local development environment"
-    task :recreate, [ "user_login" ] => [ :environment ] do |t, args|
+    task :recreate, [ "user_login", "generate_tasks" ] => [ :environment ] do |t, args|
       task("db:drop").invoke
       system "rm -rf #{File.join(Rails.root, "storage", "*/")}"
       FileUtils.touch("tmp/caching-dev.txt") unless File.exist?("tmp/caching-dev.txt")
@@ -36,7 +36,7 @@ if Rails.env.local?
       ).import!
 
       puts "DB set up complete, initializing test sets.."
-      Rake::Task["test_sets:synchronize"].invoke(args.fetch(:user_login), challenge.id)
+      Rake::Task["test_sets:synchronize"].invoke(args.fetch(:user_login), challenge.id, nil, args.fetch(:generate_tasks))
 
       puts "Test sets created, mocking data for ST"
       Rake::Task["dev:faked_st_models"].invoke

--- a/lib/tasks/test_sets.rake
+++ b/lib/tasks/test_sets.rake
@@ -1,16 +1,24 @@
 namespace :test_sets do
-  task :synchronize, [ :user_login, :challenge_id, :tasks_dir ] => [ :environment ] do |t, args|
+  task :synchronize, [ :user_login, :challenge_id, :tasks_dir, :generate ] => [ :environment ] do |t, args|
     require "test_sets_loader"
 
-    tasks_dir = args.fetch(:tasks_dir, TestSetsLoader::TASKS_DIR)
-    loader = TestSetsLoader.new(username: args.fetch(:user_login),
-                                challenge_id: args.fetch(:challenge_id),
-                                tasks_dir:)
+    tasks_dir = args[:tasks_dir] || TestSetsLoader::TASKS_DIR
+    generate = (args[:generate] || "false") == "true"
+    if generate
+      tasks_path = File.join(TestSetsLoader::FAKE_TASKS_DIR, "tasks")
+      faker = TestSetFaker::TestSetsFaker.new(tasks_path)
+      faker.generate
 
-    loader.synchronize_with_remote!
-
+      loader = TestSetsLoader.new(challenge_id: args.fetch(:challenge_id),
+                                  tasks_dir: TestSetsLoader::FAKE_TASKS_DIR)
+    else
+      loader = TestSetsLoader.new(username: args.fetch(:user_login),
+                                  challenge_id: args.fetch(:challenge_id),
+                                  tasks_dir:)
+      loader.synchronize_with_remote!
+    end
     if TestSet.count.positive?
-      puts "Test sets already in the DB, do you want to remove them and import a new one from Ares [y/n]?"
+      puts "Test sets already in the DB, do you want to remove them and import new ones [y/n]?"
       if gets.chomp == "y"
         TestSet.destroy_all
       end

--- a/lib/test_set_faker/asr_faker.rb
+++ b/lib/test_set_faker/asr_faker.rb
@@ -1,0 +1,37 @@
+class TestSetFaker::AsrFaker < TestSetFaker::BaseFaker
+  def generate
+    FileUtils.mkdir_p(@task_dir)
+
+    covost_path = File.join(@task_dir, "COVOST")
+    FileUtils.mkdir_p(covost_path)
+    [ "de", "es", "fr", "it" ].each do |lang|
+      lang_path = File.join(covost_path, lang)
+      FileUtils.mkdir_p(lang_path)
+      create_placeholder_file(lang_path, "audios.tar.gz")
+      create_placeholder_file(lang_path, "test.#{lang}")
+    end
+
+    mustc_path = File.join(@task_dir, "MUSTC")
+    FileUtils.mkdir_p(mustc_path)
+    mustc_lang_path = File.join(mustc_path, "en")
+    FileUtils.mkdir_p(mustc_lang_path)
+    create_placeholder_file(mustc_lang_path, "_audios.tar.gz")
+    create_placeholder_file(mustc_lang_path, "tst-COMMON.yaml")
+    create_placeholder_file(mustc_lang_path, "tst-COMMON.en")
+
+    acl6060_path = File.join(@task_dir, "ACL6060")
+    FileUtils.mkdir_p(acl6060_path)
+    create_placeholder_file(acl6060_path, "audios.tar.gz")
+
+    acl6060_lang_path = File.join(acl6060_path, "en")
+    FileUtils.mkdir_p(acl6060_lang_path)
+    create_placeholder_file(acl6060_lang_path, "eval.en")
+
+    dipco_path = File.join(@task_dir, "DIPCO")
+    FileUtils.mkdir_p(dipco_path)
+    dipco_lang_path = File.join(dipco_path, "en")
+    FileUtils.mkdir_p(dipco_lang_path)
+    create_placeholder_file(dipco_lang_path, "close-talk.audios.tar.gz")
+    create_placeholder_file(dipco_lang_path, "close-talk.en")
+  end
+end

--- a/lib/test_set_faker/base_faker.rb
+++ b/lib/test_set_faker/base_faker.rb
@@ -1,0 +1,13 @@
+class TestSetFaker::BaseFaker
+  def initialize(tasks_path, task_name)
+    @task_dir = File.join(tasks_path, task_name)
+  end
+
+  private
+
+    def create_placeholder_file(dir, filename)
+      filepath = File.join(dir, filename)
+
+      File.write(filepath, "# Placeholder file")
+    end
+end

--- a/lib/test_set_faker/lipread_faker.rb
+++ b/lib/test_set_faker/lipread_faker.rb
@@ -1,0 +1,14 @@
+class TestSetFaker::LipreadFaker < TestSetFaker::BaseFaker
+  def generate
+    FileUtils.mkdir_p(@task_dir)
+
+    lrs2_path = File.join(@task_dir, "LRS2")
+    FileUtils.mkdir_p(lrs2_path)
+
+    lrs2_lang_path = File.join(lrs2_path, "en")
+    FileUtils.mkdir_p(lrs2_lang_path)
+
+    create_placeholder_file(lrs2_lang_path, "en_videos.tar.gz")
+    create_placeholder_file(lrs2_lang_path, "ref.en.tsv.sorted")
+  end
+end

--- a/lib/test_set_faker/mt_faker.rb
+++ b/lib/test_set_faker/mt_faker.rb
@@ -1,0 +1,26 @@
+class TestSetFaker::MtFaker < TestSetFaker::BaseFaker
+  def generate
+    FileUtils.mkdir_p(@task_dir)
+
+    test_sets = {
+      "FLORES" => [ "en-de", "en-cs", "en-es", "en-fr", "en-it", "en-nl", "en-pt", "en-ro" ],
+      "ACL6060" => [ "en-de", "en-fr" ]
+    }
+
+    test_sets.each do |test_set, lang_pairs|
+      test_set_path = File.join(@task_dir, test_set)
+      FileUtils.mkdir_p(test_set_path)
+
+      lang_pairs.each do |lang_pair|
+        source, target = lang_pair.split("-")
+        lang_path = File.join(test_set_path, lang_pair)
+        FileUtils.mkdir_p(lang_path)
+
+        create_placeholder_file(lang_path, "devtest.#{lang_pair}.#{source}")
+        create_placeholder_file(lang_path, "devtest.#{lang_pair}.#{target}")
+        create_placeholder_file(lang_path, "#{test_set}.#{source}")
+        create_placeholder_file(lang_path, "#{test_set}.#{target}")
+      end
+    end
+  end
+end

--- a/lib/test_set_faker/slu_faker.rb
+++ b/lib/test_set_faker/slu_faker.rb
@@ -1,0 +1,24 @@
+class TestSetFaker::SluFaker < TestSetFaker::BaseFaker
+  def generate
+    FileUtils.mkdir_p(@task_dir)
+
+    slurp_path = File.join(@task_dir, "SLURP")
+    FileUtils.mkdir_p(slurp_path)
+
+    en_path = File.join(slurp_path, "en")
+    FileUtils.mkdir_p(en_path)
+    create_placeholder_file(en_path, "en_audios.tar.gz")
+    create_placeholder_file(en_path, ".en")
+
+    speechmassive_path = File.join(@task_dir, "SPEECHMASSIVE")
+    FileUtils.mkdir_p(speechmassive_path)
+
+    [ "de", "fr" ].each do |lang|
+      lang_path = File.join(speechmassive_path, lang)
+      FileUtils.mkdir_p(lang_path)
+
+      create_placeholder_file(lang_path, "#{lang}_audios.tar.gz")
+      create_placeholder_file(lang_path, ".#{lang}")
+    end
+  end
+end

--- a/lib/test_set_faker/sqa_faker.rb
+++ b/lib/test_set_faker/sqa_faker.rb
@@ -1,0 +1,14 @@
+class TestSetFaker::SqaFaker < TestSetFaker::BaseFaker
+  def generate
+    FileUtils.mkdir_p(@task_dir)
+
+    spokensquad_path = File.join(@task_dir, "SPOKENSQUAD")
+    FileUtils.mkdir_p(spokensquad_path)
+
+    spokensquad_lang_path = File.join(spokensquad_path, "en")
+    FileUtils.mkdir_p(spokensquad_lang_path)
+
+    create_placeholder_file(spokensquad_lang_path, "SPOKENSQUAD_audios.tar.gz")
+    create_placeholder_file(spokensquad_lang_path, "SPOKENSQUAD.json")
+  end
+end

--- a/lib/test_set_faker/ssum_faker.rb
+++ b/lib/test_set_faker/ssum_faker.rb
@@ -1,0 +1,14 @@
+class TestSetFaker::SsumFaker < TestSetFaker::BaseFaker
+  def generate
+    FileUtils.mkdir_p(@task_dir)
+
+    icsi_path = File.join(@task_dir, "ICSI")
+    FileUtils.mkdir_p(icsi_path)
+
+    icsi_lang_path = File.join(icsi_path, "en")
+    FileUtils.mkdir_p(icsi_lang_path)
+
+    create_placeholder_file(icsi_lang_path, "audios.tar.gz")
+    create_placeholder_file(icsi_lang_path, "ref.jsonl")
+  end
+end

--- a/lib/test_set_faker/st_faker.rb
+++ b/lib/test_set_faker/st_faker.rb
@@ -1,0 +1,59 @@
+class TestSetFaker::StFaker < TestSetFaker::BaseFaker
+  def generate
+    FileUtils.mkdir_p(@task_dir)
+
+    test_sets = {
+      "COVOST" => [ "en-de", "es-en", "fr-en", "it-en" ],
+      "MUSTC" => [ "en-de" ],
+      "MTEDX" => [ "en-es" ],
+      "ACL6060" => [ "en-de", "en-fr" ]
+    }
+
+    test_sets.each do |test_set, lang_pairs|
+      test_set_path = File.join(@task_dir, test_set)
+      FileUtils.mkdir_p(test_set_path)
+
+      if test_set == "ACL6060"
+        create_placeholder_file(test_set_path, "_audios.tar.gz")
+      end
+
+      lang_pairs.each do |lang_pair|
+        source, target = lang_pair.split("-")
+        lang_path = File.join(test_set_path, lang_pair)
+        FileUtils.mkdir_p(lang_path)
+
+        if test_set == "COVOST"
+          create_placeholder_file(lang_path, "test.#{lang_pair}.#{source}")
+          create_placeholder_file(lang_path, "test.#{lang_pair}.#{target}")
+          create_placeholder_file(lang_path, "#{test_set}.#{source}")
+          create_placeholder_file(lang_path, "#{test_set}.#{target}")
+          create_placeholder_file(lang_path, "#{test_set}_audios.tar.gz")
+          create_placeholder_file(lang_path, "#{test_set}tst-COMMON.yaml")
+          create_placeholder_file(lang_path, "#{test_set}test.yaml")
+          create_placeholder_file(lang_path, "ST_#{test_set}_#{source}.tgz")
+        elsif test_set == "MUSTC"
+          create_placeholder_file(lang_path, "test.#{lang_pair}.#{source}")
+          create_placeholder_file(lang_path, "test.#{lang_pair}.#{target}")
+          create_placeholder_file(lang_path, "#{test_set}.#{source}")
+          create_placeholder_file(lang_path, "#{test_set}.#{target}")
+          create_placeholder_file(lang_path, "#{test_set}_audios.tar.gz")
+          create_placeholder_file(lang_path, "#{test_set}tst-COMMON.yaml")
+          create_placeholder_file(lang_path, "#{test_set}test.yaml")
+          create_placeholder_file(lang_path, "ST_#{test_set}_#{source}.tgz")
+        elsif test_set == "MTEDX"
+          create_placeholder_file(lang_path, "test.#{lang_pair}.#{source}")
+          create_placeholder_file(lang_path, "test.#{lang_pair}.#{target}")
+          create_placeholder_file(lang_path, "#{test_set}.#{source}")
+          create_placeholder_file(lang_path, "#{test_set}.#{target}")
+          create_placeholder_file(lang_path, "#{test_set}_audios.tar.gz")
+          create_placeholder_file(lang_path, "#{test_set}tst-COMMON.yaml")
+          create_placeholder_file(lang_path, "#{test_set}test.yaml")
+          create_placeholder_file(lang_path, "ST_#{test_set}_#{source}.tgz")
+        elsif test_set == "ACL6060"
+          create_placeholder_file(lang_path, ".#{target}")
+          create_placeholder_file(lang_path, ".#{source}")
+        end
+      end
+    end
+  end
+end

--- a/lib/test_set_faker/sum_faker.rb
+++ b/lib/test_set_faker/sum_faker.rb
@@ -1,0 +1,16 @@
+class TestSetFaker::SumFaker < TestSetFaker::BaseFaker
+  def generate
+    FileUtils.mkdir_p(@task_dir)
+
+    [ "ICSI", "AUTOMIN" ].each do |test_set|
+      test_set_path = File.join(@task_dir, test_set)
+      FileUtils.mkdir_p(test_set_path)
+
+      lang_path = File.join(test_set_path, "en")
+      FileUtils.mkdir_p(lang_path)
+
+      create_placeholder_file(lang_path, "src.jsonl")
+      create_placeholder_file(lang_path, "ref.jsonl")
+    end
+  end
+end

--- a/lib/test_set_faker/test_sets_faker.rb
+++ b/lib/test_set_faker/test_sets_faker.rb
@@ -1,0 +1,53 @@
+class TestSetFaker::TestSetsFaker
+  def initialize(tasks_path)
+    @tasks_path = tasks_path
+  end
+
+  def generate
+    note "Creating mirrored structure without downloading files"
+    FileUtils.rm_rf(@tasks_path)
+    FileUtils.mkdir_p(@tasks_path)
+    task_dirs = [ "ST", "MT", "ASR", "SUM", "SSUM", "SQA", "SLU", "LIPREAD", "TTS" ]
+
+    task_dirs.each do |task_name|
+      faker_class = self.class.for(task_name)
+      faker = faker_class.new(@tasks_path, task_name)
+      faker.generate
+    end
+    note "Mirrored structure created successfully"
+  end
+
+  def self.for(task_name)
+    case task_name.upcase
+    when "ST" then TestSetFaker::StFaker
+    when "MT" then TestSetFaker::MtFaker
+    when "ASR" then TestSetFaker::AsrFaker
+    when "SUM" then TestSetFaker::SumFaker
+    when "SSUM" then TestSetFaker::SsumFaker
+    when "SQA" then TestSetFaker::SqaFaker
+    when "SLU" then TestSetFaker::SluFaker
+    when "LIPREAD" then TestSetFaker::LipreadFaker
+    when "TTS" then TestSetFaker::TtsFaker
+    else TestSetFaker::UnknownFaker
+    end
+  end
+
+  private
+
+    def note(msg)
+      puts "\e[#{34}m#{msg}\e[0m"
+    end
+end
+
+require "test_set_faker/base_faker"
+require "test_set_faker/unknown_faker"
+require "test_set_faker/st_faker"
+require "test_set_faker/mt_faker"
+require "test_set_faker/asr_faker"
+require "test_set_faker/sum_faker"
+require "test_set_faker/ssum_faker"
+require "test_set_faker/sqa_faker"
+require "test_set_faker/slu_faker"
+require "test_set_faker/lipread_faker"
+require "test_set_faker/tts_faker"
+require "test_set_faker/test_sets_faker"

--- a/lib/test_set_faker/tts_faker.rb
+++ b/lib/test_set_faker/tts_faker.rb
@@ -1,0 +1,14 @@
+class TestSetFaker::TtsFaker < TestSetFaker::BaseFaker
+  def generate
+    FileUtils.mkdir_p(@task_dir)
+
+    ljspeech_path = File.join(@task_dir, "LJSPEECH")
+    FileUtils.mkdir_p(ljspeech_path)
+
+    ljspeech_lang_path = File.join(ljspeech_path, "en")
+    FileUtils.mkdir_p(ljspeech_lang_path)
+
+    create_placeholder_file(ljspeech_lang_path, ".src.en.tsv")
+    create_placeholder_file(ljspeech_lang_path, ".ref.en.tsv")
+  end
+end

--- a/lib/test_set_faker/unknown_faker.rb
+++ b/lib/test_set_faker/unknown_faker.rb
@@ -1,0 +1,12 @@
+class TestSetFaker::UnknownFaker < TestSetFaker::BaseFaker
+  def generate
+    error "Unable to create structure for unknown task - faker unknown"
+  end
+
+  private
+
+    def error(msg)
+      puts "\e[#{31}m  - #{msg}\e[0m"
+      raise "Unknown task faker: #{msg}"
+    end
+end

--- a/lib/test_sets_loader.rb
+++ b/lib/test_sets_loader.rb
@@ -1,11 +1,12 @@
 class TestSetsLoader
   HOSTNAME = "login01.ares.cyfronet.pl"
   TASKS_DIR = File.join(Rails.root, "tmp")
+  FAKE_TASKS_DIR = File.join(Rails.root, "tmp", "fake_tasks")
   REMOTE_TASKS_DIR = "/net/pr2/projects/plgrid/plggmeetween/tasks"
   TASKS_YAML_PATH = File.join(Rails.root, "db", "data", "tasks.yml")
   TEST_SETS_YAML_PATH = File.join(Rails.root, "db", "data", "test_sets.yml")
 
-  def initialize(username:, challenge_id:, hostname: HOSTNAME, remote_tasks_dir: REMOTE_TASKS_DIR, tasks_dir: TASKS_DIR)
+  def initialize(username: nil, challenge_id:, hostname: HOSTNAME, remote_tasks_dir: REMOTE_TASKS_DIR, tasks_dir: TASKS_DIR)
     @username = username
     @challenge_id = challenge_id
     @hostname = hostname


### PR DESCRIPTION

Instead of loading a ton of data from ares, we can simply mock the data. It's based on temp tasks that I had downloaded a long time ago - the data was not complete, but good enough to have a dev sample. I didn't bother downloading the whole set. This is meant to be quick and dirty since it's used for dev purposes and I needed it to test staging  

Vibe coded task