### PR TITLE
Add internal leaderboard

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -21,7 +21,7 @@ class Challenge < ApplicationRecord
   validates :name, :starts_at, :ends_at, presence: true
   validates :ends_at, comparison: { greater_than: :starts_at }
 
-  VISIBILITIES = { leaderboard_released: "leaderboard_released", scores_released: "scores_released" }
+  VISIBILITIES = { internal_leaderboard: "internal_leaderboard", leaderboard_released: "leaderboard_released", scores_released: "scores_released" }
   enum :visibility, VISIBILITIES
 
   before_create :set_default_texts

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -60,7 +60,9 @@ class ApplicationPolicy
     end
 
     def leaderboard_released?
-      Current.challenge.leaderboard_released? || Current.user&.force_challenge_open?
+      Current.challenge.leaderboard_released? ||
+      (Current.challenge.internal_leaderboard? && (challenge_admin? || challenge_manager?)) ||
+      Current.user&.force_challenge_open?
     end
 
     class Scope
@@ -70,7 +72,9 @@ class ApplicationPolicy
       end
 
       def leaderboard_released?
-        Current.challenge.leaderboard_released?
+        Current.challenge.leaderboard_released? ||
+        (Current.challenge.internal_leaderboard? && (challenge_admin? || challenge_manager?)) ||
+        Current.user&.force_challenge_open?
       end
 
       def resolve

--- a/app/views/challenges/tasks/leaderboards/_internal_leaderboard_notice.html.erb
+++ b/app/views/challenges/tasks/leaderboards/_internal_leaderboard_notice.html.erb
@@ -1,0 +1,5 @@
+  <% if Current.challenge.internal_leaderboard? %>
+    <div class="rounded-lg border border-yellow-400 bg-yellow-300 items-center mb-2 overflow-hidden px-6 py-2.5 sm:px-3.5 sm:before:flex-1">
+      <p class="font-bold text-center text-yellow-900"> This page is currently only visible to challenge managers and admins. To make it visible to all participants, please update the challenge visibility settings. </p>
+    </div>
+  <% end %>

--- a/app/views/challenges/tasks/leaderboards/show.html.erb
+++ b/app/views/challenges/tasks/leaderboards/show.html.erb
@@ -7,6 +7,7 @@
   <% breadcrumb :task_leaderboard, @task %>
   <%= mltop_title "#{@task.name} Leaderboard" %>
   <%= render "challenges/tasks/menu", task: @task %>
+  <%= render "internal_leaderboard_notice" %>
   <%= render "filters", rows: @rows %>
   <% if @rows.size.positive? %>
     <%= render "leaderboard", task: @task, rows: @rows %>

--- a/app/views/challenges/test_sets/leaderboards/_internal_leaderboard_notice.html.erb
+++ b/app/views/challenges/test_sets/leaderboards/_internal_leaderboard_notice.html.erb
@@ -1,0 +1,5 @@
+<% if Current.challenge.internal_leaderboard? %>
+  <div class="rounded-lg border border-yellow-400 bg-yellow-300 items-center mb-2 overflow-hidden px-6 py-2.5 sm:px-3.5 sm:before:flex-1">
+    <p class="font-bold text-center text-yellow-900"> This page is currently only visible to challenge managers and admins. To make it visible to all participants, please update the challenge visibility settings. </p>
+  </div>
+<% end %>

--- a/app/views/challenges/test_sets/leaderboards/show.html.erb
+++ b/app/views/challenges/test_sets/leaderboards/show.html.erb
@@ -8,6 +8,7 @@
   <% breadcrumb :test_set_leaderboard, @test_set %>
   <%= mltop_title "#{@task.name}: #{@test_set.name} Leaderboard" %>
   <%= render "challenges/test_sets/menu", test_set: @test_set %>
+  <%= render "internal_leaderboard_notice" %>
   <%= render "filters" %>
   <% if @rows.size.positive? %>
     <%= render "leaderboard", task: @task, test_set: @test_set, rows: @rows %>

--- a/db/migrate/20260505111125_update_challenge_visibility.rb
+++ b/db/migrate/20260505111125_update_challenge_visibility.rb
@@ -1,0 +1,9 @@
+class UpdateChallengeVisibility < ActiveRecord::Migration[8.1]
+  def up
+    ActiveRecord::Base.connection.execute("ALTER TYPE challenge_visibility ADD VALUE 'internal_leaderboard'")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Can't remove internal_leaderboard from challenge_visibility enum"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_12_122438) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_05_111125) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "challenge_visibility", ["leaderboard_released", "scores_released"]
+  create_enum "challenge_visibility", ["leaderboard_released", "scores_released", "internal_leaderboard"]
   create_enum "consent_target", ["model", "challenge"]
   create_enum "evaluator_kind", ["automatic", "manual"]
   create_enum "format", ["video", "audio", "text"]

--- a/test/controllers/test_sets/leaderboards_controller_test.rb
+++ b/test/controllers/test_sets/leaderboards_controller_test.rb
@@ -13,6 +13,20 @@ module TestSets
       assert :unauthorized, response.status
     end
 
+    test "should get index when internal released and is a manager/admin of challenge" do
+      challenge_member_signs_in("szymon", teams: [ "plggmeetween" ])
+      challenges(:global).update(visibility: "internal_leaderboard")
+      membership = Membership.find_by(user: users(:szymon), challenge: challenges(:global))
+      membership.update(roles: [ :manager ])
+      get test_set_leaderboard_path(test_set_id: test_sets("flores"))
+      assert_response :success
+      membership.update(roles: [ :admin ])
+      get test_set_leaderboard_path(test_set_id: test_sets("flores"))
+      assert_response :success
+      membership.update(roles: [])
+      assert :unauthorized, response.status
+    end
+
     test "should get index when force_challenge open is set to true" do
       challenge_member_signs_in("szymon")
       challenges(:global).update(visibility: nil)


### PR DESCRIPTION
Managers should be able to see the scores of submissions in leaderboard format below they release the scores to the pulbic